### PR TITLE
Put the cmdliner stuff in the same module tree

### DIFF
--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean install build
 all: build test doc
 
-NAME=xcp-api-client
+NAME=xapi-idl
 
 LWT ?= $(shell if ocamlfind query lwt.ssl >/dev/null 2>&1; then echo --enable-lwt; fi)
 ASYNC ?= $(shell if ocamlfind query async_core >/dev/null 2>&1; then echo --enable-async; fi)

--- a/python/storage.py
+++ b/python/storage.py
@@ -172,7 +172,22 @@ class VDI_server_dispatcher:
         sr = args["sr"]
         if type(sr) <> type(""):
             raise (TypeError("string", repr(sr)))
-        results = self._impl.create(dbg, sr)
+        if not(args.has_key('name_label')):
+            raise UnmarshalException('argument missing', 'name_label', '')
+        name_label = args["name_label"]
+        if type(name_label) <> type(""):
+            raise (TypeError("string", repr(name_label)))
+        if not(args.has_key('name_description')):
+            raise UnmarshalException('argument missing', 'name_description', '')
+        name_description = args["name_description"]
+        if type(name_description) <> type(""):
+            raise (TypeError("string", repr(name_description)))
+        if not(args.has_key('size')):
+            raise UnmarshalException('argument missing', 'size', '')
+        size = args["size"]
+        if not(is_long(size)):
+            raise (TypeError("int64", repr(size)))
+        results = self._impl.create(dbg, sr, name_label, name_description, size)
         if type(results['vdi']) <> type(""):
             raise (TypeError("string", repr(results['vdi'])))
         if type(results['content_id']) <> type(""):
@@ -507,7 +522,7 @@ class VDI_skeleton:
     """Operations which operate on Virtual Disk Images"""
     def __init__(self):
         pass
-    def create(self, dbg, sr):
+    def create(self, dbg, sr, name_label, name_description, size):
         """Operations which operate on Virtual Disk Images"""
         raise Unimplemented("VDI.create")
     def snapshot(self, dbg, sr):
@@ -541,7 +556,7 @@ class VDI_test:
     """Operations which operate on Virtual Disk Images"""
     def __init__(self):
         pass
-    def create(self, dbg, sr):
+    def create(self, dbg, sr, name_label, name_description, size):
         """Operations which operate on Virtual Disk Images"""
         result = {}
         result["new_vdi"] = { "vdi": "string", "content_id": "string", "name_label": "string", "name_description": "string", "is_a_snapshot": True, "snapshot_time": "string", "snapshot_of": "string", "read_only": True, "virtual_size": 0L, "physical_utilisation": 0L }

--- a/rpc-light/vdi.create/request
+++ b/rpc-light/vdi.create/request
@@ -1,25 +1,10 @@
 <?xml version="1.0"?><methodCall><methodName>VDI.create</methodName>
   <params><param><value>
      <struct><member><name>dbg</name><value>OpaqueRef:9aa50d0c-4bf8-a03e-9796-3ca65459638a</value></member>
-             <member><name>sr</name><value>65a478f3-066a-71e6-339e-025d8ae4e992</value></member>
-             <member><name>vdi_info</name><value>
-               <struct><member><name>vdi</name><value></value></member>
-                       <member><name>sr</name><value></value></member>
-                       <member><name>content_id</name><value></value></member>
-                       <member><name>name_label</name><value>test</value></member>
-                       <member><name>name_description</name><value></value></member>
-                       <member><name>ty</name><value>user</value></member>
-                       <member><name>metadata_of_pool</name><value></value></member>
-                       <member><name>is_a_snapshot</name><value><boolean>0</boolean></value></member>
-                       <member><name>snapshot_time</name><value>19700101T00:00:00Z</value></member>
-                       <member><name>snapshot_of</name><value></value></member>
-					   <member><name>read_only</name><value><boolean>0</boolean></value></member>
-                       <member><name>virtual_size</name><value>0</value></member>
-                       <member><name>physical_utilisation</name><value>0</value></member>
-					   <member><name>persistent</name><value><boolean>1</boolean></value></member>
-					   <member><name>sm_config</name><value><struct></struct></value></member>
-               </struct></value></member>
-             <member><name>params</name><value><struct></struct></value></member>
+	     <member><name>sr</name><value>65a478f3-066a-71e6-339e-025d8ae4e992</value></member>
+	     <member><name>name_label</name><value>The name_label</value></member>
+	     <member><name>name_description</name><value>The description</value></member>
+             <member><name>size</name><value>0</value></member>
      </struct>
    </value></param></params>
 </methodCall>

--- a/smapiv2.ml
+++ b/smapiv2.ml
@@ -214,6 +214,21 @@ let api =
               description = "[create task sr vdi_info params] creates a new VDI in [sr] using [vdi_info]. Some fields in the [vdi_info] may be modified (e.g. rounded up), so the function returns the vdi_info which was used.";
               inputs = [
                 sr;
+                {
+                  Arg.name = "name_label";
+                  ty = Basic String;
+                  description = "A human-readable name to associate with the new disk. This name is intended to be short, to be a good summary of the disk."
+                };
+                {
+                  Arg.name = "name_description";
+                  ty = Basic String;
+                  description = "A human-readable description to associate with the new disk. This can be arbitrarily long, up to the general string size limit."
+                };
+                {
+                  Arg.name = "size";
+                  ty = Basic Int64;
+                  description = "A minimum size (in bytes) for the disk. Depending on the characteristics of the implementation this may be rounded up to (for example) the nearest convenient block size. The created disk will not be smaller than this size.";
+                };
               ];
               outputs = [
                 { Arg.name = "new_vdi";


### PR DESCRIPTION
This is more convenient for functorisation.

Signed-off-by: David Scott dave.scott@citrix.com
