### PR TITLE
Add per-SR datasource URIs

### DIFF
--- a/generator/src/control.ml
+++ b/generator/src/control.ml
@@ -22,6 +22,11 @@ let api =
           "total_space", Basic Int64, String.concat " " [
             "Total physical size of the backing storage (in bytes)";
           ];
+          "datasources", Array (Basic String), String.concat " " [
+            "URIs naming datasources: time-varying quantities representing anything";
+            "from disk access latency to free space. The entities named by these URIs";
+            "are self-describing.";
+          ];
         ]
       )) in
   let volume_decl =


### PR DESCRIPTION
These should point to xenostat-format shared memory pages containing
time-varying data. Suitable uses include

- free space in the SR
- I/O latency

Signed-off-by: David Scott <dave.scott@citrix.com>