### PR TITLE
Add SR.probe

### DIFF
--- a/generator/src/control.ml
+++ b/generator/src/control.ml
@@ -370,6 +370,23 @@ let api =
           type_decls = [];
           methods = [
             {
+              Method.name = "probe";
+              description = "[probe uri]: looks for existing SRs on the storage device";
+              inputs = [
+                uri;
+              ];
+              outputs = [
+               { Arg.name = "result";
+                 ty = 
+                   Type.Struct (
+                     ("srs", Type.(Array sr_stat), "SRs found on this storage device"), [
+                      "uris", Type.(Array (Basic String)), "Other possible URIs which may contain SRs"
+                   ]);
+                 description = "Contents of the storage device";
+               }
+              ];
+            };
+            {
               Method.name = "create";
               description = "[create uri configuration]: creates a fresh SR";
               inputs = [


### PR DESCRIPTION
SR.probe takes a `uri` argument which could be `iscsi://target` and
then returns a struct with

- SRs: this means I found specific SRs (great!)
- URIs: this means I have some suggestions for related URIs you could
  try. This could be 'scsi://target/iqn'. The client could then
  perform `SR.probe` calls with these URLs to explore the storage.

Signed-off-by: David Scott <dave.scott@citrix.com>
