### PR TITLE
Update `handle_exception` to send back XenAPI errors

### DIFF
--- a/python/xapi/__init__.py
+++ b/python/xapi/__init__.py
@@ -55,6 +55,16 @@ def handle_exception(e, code = None, params = None):
     print >>sys.stdout, json.dumps(results)
     sys.exit(1)
 
+class XenAPIException(Exception):
+    def __init__(self, code, params):
+        Exception.__init__(self)
+        if type(code) <> type("") and type(code) <> type(u""):
+            raise (TypeError("string", repr(code)))
+        if type(params) <> type([]):
+            raise (TypeError("list", repr(params)))
+        self.code = code
+        self.params = params
+
 class MissingDependency(Exception):
     def __init__(self, missing):
         self.missing = missing

--- a/python/xapi/__init__.py
+++ b/python/xapi/__init__.py
@@ -29,19 +29,30 @@ def log(txt):
 def success(result):
     return { "Status": "Success", "Value": result }
 
-def handle_exception(e):
+def handle_exception(e, code = None, params = None):
     s = sys.exc_info()
     files = []
     lines = []
     for slot in traceback.extract_tb(s[2]):
         files.append(slot[0])
         lines.append(slot[1])
-    results = {
+    backtrace = {
       "error": str(s[1]),
       "files": files,
       "lines": lines,
     }
-    print >>sys.stderr, json.dumps(results)
+    code = "SR_BACKEND_FAILURE"
+    params = [ str(s[1]) ]
+    if hasattr(e, "code"):
+      code = e.code
+    if hasattr(e, "params"):
+      params = e.params
+    results = {
+      "code": code,
+      "params": params,
+      "backtrace": backtrace,
+    }
+    print >>sys.stdout, json.dumps(results)
     sys.exit(1)
 
 class MissingDependency(Exception):


### PR DESCRIPTION
`handle_exception` can return an xcp-idl `Backend_error_with_backtrace`
which includes:

- XenAPI error code (optional, defaults to `SR_BACKEND_ERROR`)
- XenAPI error params
- error backtrace

Signed-off-by: David Scott <dave.scott@citrix.com>