### PR TITLE
Clean up xapi.storage.log log-entries

### DIFF
--- a/python/xapi/storage/log.py
+++ b/python/xapi/storage/log.py
@@ -14,8 +14,7 @@ def configure_logging():
     _LOGGER.setLevel(LOG_LEVEL)
 
     formatter = logging.Formatter(
-        '%(asctime)s - [%(process)d] - %(levelname)s - %(message)s',
-        '%Y-%m-%d %H:%M:%S')
+        'SMAPIv3: [%(process)d] - %(levelname)s - %(message)s')
 
     handlers = []
 


### PR DESCRIPTION
This commit contains two changes:
   - Don't log the timestamp explicitly, as syslog already adds this implicitly.
   - Flag log-entries as belonging to SMAPIv3 - this is similar to SMAPIv1
     flagging as SM.

Signed-off-by: Robert Breker <robert.breker@citrix.com>