### PR TITLE
fix opam dep conflict with rpc

### DIFF
--- a/opam
+++ b/opam
@@ -14,7 +14,7 @@ remove: [
   [make "uninstall" "PREFIX=%{prefix}%"]
 ]
 depends: [
-  "cow" {< "2.0.0"}
+  "cow"
   "rpc"
   "caml2html"
   "xmlm"


### PR DESCRIPTION
rpc requires cow > 2.0.0 to build (fails with 1.4.0), and xapi-storage requires
cow < 2.0.0.
But obviously we are able to build both using the .spec  files, so fix the opam
dependency to allow co-installation with rpc.

After this  change I was able to pin and install both xapi and xapi-storage in the same opam switch.