### PR TITLE
CA-272163: do not lose exception type during RPC

### DIFF
--- a/python/xapi/__init__.py
+++ b/python/xapi/__init__.py
@@ -23,7 +23,7 @@ def handle_exception(e, code=None, params=None):
         "lines": lines,
     }
     code = "SR_BACKEND_FAILURE"
-    params = [str(s[1])]
+    params = [s[0].__name__, str(s[1])]
     if hasattr(e, "code"):
         code = e.code
     if hasattr(e, "params"):


### PR DESCRIPTION
If the backend raises a subclass of Rpc_light_failure we were
only passing through the arguments, but not the actual exception name.
So the caller had no way to tell which exception we raised.

We need to know the correct exception when we raise the snapshot redirect
exception, otherwise XAPI just receives a generic exception it doesn't know what
to do with:
result.contents: ["Backend_error_with_backtrace",["SR_BACKEND_FAILURE",["{\"error\":\"7fe5d42c-e165-4814-8263-2408cd132a61\"

This is related to the exception transformation we discussed with @gaborigloi 

Signed-off-by: Edwin Török <edvin.torok@citrix.com>