### PR TITLE
SR.attach uuid

### DIFF
--- a/generator/src/control.ml
+++ b/generator/src/control.ml
@@ -463,10 +463,11 @@ let api =
             {
               Method.name = "attach";
               description = String.concat " "[
-                "[attach uri]: attaches the SR to the local host. Once an SR";
+                "[attach uuid uri]: attaches the SR to the local host. Once an SR";
                 "is attached then volumes may be manipulated.";
               ];
               inputs = [
+                uuid;
                 uri;
               ];
               outputs = [


### PR DESCRIPTION
When doing SR.create the SM can put the uuid into the uri it returns,
however with SR.introduce we don't have the uuid inside the uri.

Always pass the uuid explicitly to attach so that both create and introduce
works.

This needs to be merged together with the xapi-storage-script PR.