### PR TITLE
[477 idl part2] sharable flag, SR.create/SR.attach API change, introduce redirection exception

### DIFF
--- a/generator/lib/control.ml
+++ b/generator/lib/control.ml
@@ -154,6 +154,10 @@ let api =
         TyDecl.name = "Cancelled";
         description = "The task has been asynchronously cancelled";
         ty = Type.(Basic String);
+      }; {
+        TyDecl.name = "Activated_on_another_host";
+        description = "The Volume is already active on another host";
+        ty = Type.(Basic String);
       };
     ];
     type_decls = [
@@ -266,6 +270,10 @@ let api =
                 "written to; they are intended for backup/restore only.";
                 "Note the name and description are copied but any extra";
                 "metadata associated by [set] is not copied.";
+                "This can raise Activated_on_another_host(host_installation_uuid)";
+                "if the VDI is already active on another host and snapshots";
+                "can only be taken on the host that has the VDI active (if any).";
+                "XAPI will take care of redirecting the request to the proper host"
               ];
               inputs = [
                 sr;

--- a/generator/lib/control.ml
+++ b/generator/lib/control.ml
@@ -14,7 +14,12 @@ let api =
           "The URI identifying this volume. A typical value would be a";
           "file:// URI pointing to a directory or block device.";
           ]),
-        [ "name", Basic String, String.concat " " [
+        [ "uuid", Option (Basic String), String.concat " " [
+              "Uuid that uniquely identifies this SR, if one is available. ";
+              "For SRs that are created by SR.create, this should be the ";
+              "value passed into that call, if it is possible to persist ";
+              "it."];
+          "name", Basic String, String.concat " " [
           "Short, human-readable label for the SR.";
           ];
           "description", Basic String, String.concat " " [
@@ -105,6 +110,11 @@ let api =
     Arg.name = "uri";
     ty = Type.(Basic String);
     description = "The Storage Repository URI";
+  } in
+  let uuid = {
+    Arg.name = "uuid";
+    ty = Type.(Basic String);
+    description = "A uuid to associate with the SR."
   } in
   {
     Interfaces.name = "volume";
@@ -404,8 +414,9 @@ let api =
             };
             {
               Method.name = "create";
-              description = "[create uri name description configuration]: creates a fresh SR";
+              description = "[create uuid uri name description configuration]: creates a fresh SR";
               inputs = [
+                uuid;
                 uri;
                 { Arg.name = "name";
                   ty = Type.(Basic String);
@@ -425,7 +436,7 @@ let api =
                   ];
                 };
               ];
-              outputs = []
+              outputs = [uri]
             };
             {
               Method.name = "attach";

--- a/generator/lib/control.ml
+++ b/generator/lib/control.ml
@@ -463,10 +463,11 @@ let api =
             {
               Method.name = "attach";
               description = String.concat " "[
-                "[attach uri]: attaches the SR to the local host. Once an SR";
+                "[attach uuid uri]: attaches the SR to the local host. Once an SR";
                 "is attached then volumes may be manipulated.";
               ];
               inputs = [
+                uuid;
                 uri;
               ];
               outputs = [

--- a/generator/lib/control.ml
+++ b/generator/lib/control.ml
@@ -74,6 +74,11 @@ let api =
             "volume are created read-only; for example because they are snapshots";
             "of some other VDI.";
           ];
+          "sharable", Basic Boolean, String.concat " " [
+            "Indicates whether the VDI can be attached by";
+            "multiple hosts at once.";
+            "This is used for example by the HA statefile and XAPI redo log."
+          ];
           "virtual_size", Basic Int64, String.concat " " [
             "Size of the volume from the perspective of a VM (in bytes)";
           ];
@@ -235,6 +240,15 @@ let api =
                     "characteristics of the implementation this may be rounded";
                     "up to (for example) the nearest convenient block size. The";
                     "created disk will not be smaller than this size.";
+                  ]
+                };
+                {
+                  Arg.name = "sharable";
+                  ty = Basic Boolean;
+                  description = String.concat " " [
+                    "Indicates whether the VDI can be attached by";
+                    "multiple hosts at once.";
+                    "This is used for example by the HA statefile and XAPI redo log."
                   ]
                 };
               ];

--- a/generator/lib/ocaml.ml
+++ b/generator/lib/ocaml.ml
@@ -63,6 +63,7 @@ let type_decl env t =
     Block [ typeof ~expand_aliases:true env t.TyDecl.ty ];
     Line "[@@deriving rpc]";
     Line (sprintf "(** %s *)" t.TyDecl.description);
+    Line "" (* avoid ambigous doc comment *)
   ]
 
 let rec example_value_of env =
@@ -112,6 +113,7 @@ let exn_decl env e =
     Line "[@@deriving rpc]";
     Line (sprintf "exception %s of %s" e.TyDecl.name (String.concat " * " (List.map Type.ocaml_of_t args)));
     Line (sprintf "(** %s *)" e.TyDecl.description);
+    Line "" (* avoid ambigous doc comment *)
   ]
 
 let rpc_of_exns env es =
@@ -472,7 +474,6 @@ let client_of_interfaces env is =
   List.concat (List.map (client_of_interface env) is.Interfaces.interfaces)
 
 let of_interfaces env i =
-  let open Printf in
   [
     Line "(* Automatically generated code - DO NOT MODIFY *)";
     Line "";

--- a/generator/lib/python.ml
+++ b/generator/lib/python.ml
@@ -310,6 +310,8 @@ let commandline_parse env i m =
         List.map (fun a -> match a.Arg.ty with
         | Type.Dict(_, _) ->
           Line (sprintf "parser.add_argument('--%s', default = {}, nargs=2, action=xapi.ListAction, help='%s')" a.Arg.name a.Arg.description)
+        | Type.Basic(Boolean) ->
+          Line (sprintf "parser.add_argument('--%s', action='store_true', help='%s')" a.Arg.name a.Arg.description)
         | _ ->
           Line (sprintf "parser.add_argument('%s', action='store', help='%s')" a.Arg.name a.Arg.description)
         ) m.Method.inputs

--- a/generator/lib/types.ml
+++ b/generator/lib/types.ml
@@ -267,7 +267,6 @@ let dump_ident_mappings idents =
        Printf.printf "%10s %20s %s\n" i.Ident.id (String.concat "/" i.Ident.name) (Type.string_of_t i.Ident.ty)) idents
 
 let resolve_references (idents: (string * Ident.t) list) i =
-  let open Type in
 
   let of_interface i =
     let scope = [ i.Interface.name ] in
@@ -296,7 +295,7 @@ module To_rpclight = struct
     let of_args name args =
       add (sprintf "@[type %s = {@." name);
       List.iter
-        (fun { Arg.name = name; ty = ty } ->
+        (fun { Arg.name = name; ty = ty; _ } ->
            add (sprintf "@[%s@ :@ %s;@.@]" name (Type.ocaml_of_t ty))
         ) args;
       add (sprintf "@.}@.@]") in

--- a/python/xapi/__init__.py
+++ b/python/xapi/__init__.py
@@ -23,7 +23,7 @@ def handle_exception(e, code=None, params=None):
         "lines": lines,
     }
     code = "SR_BACKEND_FAILURE"
-    params = [str(s[1])]
+    params = [s[0].__name__, str(s[1])]
     if hasattr(e, "code"):
         code = e.code
     if hasattr(e, "params"):


### PR DESCRIPTION
This is part of the SMAPIv3 interface  change from `feature/REQ477/master`,
has to be merged together with these PRs:
xapi-project/sm-cli#26
xapi-project/xapi-storage-script#56
xapi-project/xcp-idl#202
https://github.com/xapi-project/xen-api/pull/3433

The sharable flag is explained in the xcp-idl commit: https://github.com/xapi-project/xcp-idl/commit/c8bfaf9d61c547df42fac12f5d05b0165e24b83b

SMAPIv3:
The activated on exception/redirection is explained here (SMAPIv3 can require snapshots to be taken on the host that has the VM running, instead of the master): https://github.com/xapi-project/xen-api/commit/620acd20e2753a7f10a970e6f1850b325fea082a
SMAPIv2 uses a similar mechanism internally to redirect requests to the master (e.g. in case of storage migration).
