### PR TITLE
CA-283728: put generated code into new namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ env:
     - PACKAGE=xapi-storage
     - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam
 script:
-  - flake8 --show-source python
+  - flake8 --show-source python --ignore E201,E202,E301,E302,E305,E501,F401,W292,E402,W503
   - bash -ex .travis-opam.sh

--- a/generator/src/main.ml
+++ b/generator/src/main.ml
@@ -23,7 +23,7 @@ let _ =
   if !gen_python then
     List.iter
       (fun api ->
-         with_output_file (Printf.sprintf "xapi/storage/api/%s.py" api.Interfaces.name)
+         with_output_file (Printf.sprintf "xapi/storage/api/v4/%s.py" api.Interfaces.name)
            (fun oc ->
               let idents, api = resolve_refs_in_api api in
               output_string oc (Python.of_interfaces idents api |> Python.string_of_ts)

--- a/python/jbuild
+++ b/python/jbuild
@@ -7,7 +7,7 @@
     (files_recursively_in .)
   ))
   (action (progn
-    (run mkdir -p xapi/storage/api)
+    (run mkdir -p xapi/storage/api/v4)
     (run ${<} -python)
   ))
 ))

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,5 +5,6 @@ setup(name="xapi-storage",
       author='David Scott',
       author_email='dave@recoil.org',
       url='https://github.com/xapi-project/xapi-storage/',
-      packages=['xapi', 'xapi.storage', 'xapi.storage.api'],
+      packages=['xapi', 'xapi.storage', 'xapi.storage.api',
+                'xapi.storage.api.v4'],
       )

--- a/python/xapi/__init__.py
+++ b/python/xapi/__init__.py
@@ -1,5 +1,30 @@
 #!/usr/bin/env python
 
+"""
+Copyright (c) 2013-2018, Citrix Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
 import sys
 import traceback
 import json

--- a/python/xapi/storage/api/datapath.py
+++ b/python/xapi/storage/api/datapath.py
@@ -1,9 +1,14 @@
-from xapi import *
+from xapi import success, Rpc_light_failure, InternalError, UnmarshalException, TypeError, is_long, UnknownMethod
+import xapi
+import sys
+import json
+import argparse
 import traceback
+import logging
 class Unimplemented(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])
-        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+        if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
             raise (TypeError("string", repr(arg_0)))
         self.arg_0 = arg_0
 class Datapath_server_dispatcher:
@@ -13,133 +18,133 @@ class Datapath_server_dispatcher:
         self._impl = impl
     def open(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('uri')):
+        if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
-        if type(uri) <> type("") and type(uri) <> type(u""):
+        if not isinstance(uri, str) and not isinstance(uri, unicode):
             raise (TypeError("string", repr(uri)))
-        if not(args.has_key('persistent')):
+        if not('persistent' in args):
             raise UnmarshalException('argument missing', 'persistent', '')
         persistent = args["persistent"]
-        if type(persistent) <> type(True):
+        if not isinstance(persistent, bool):
             raise (TypeError("bool", repr(persistent)))
         results = self._impl.open(dbg, uri, persistent)
         return results
     def attach(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('uri')):
+        if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
-        if type(uri) <> type("") and type(uri) <> type(u""):
+        if not isinstance(uri, str) and not isinstance(uri, unicode):
             raise (TypeError("string", repr(uri)))
-        if not(args.has_key('domain')):
+        if not('domain' in args):
             raise UnmarshalException('argument missing', 'domain', '')
         domain = args["domain"]
-        if type(domain) <> type("") and type(domain) <> type(u""):
+        if not isinstance(domain, str) and not isinstance(domain, unicode):
             raise (TypeError("string", repr(domain)))
         results = self._impl.attach(dbg, uri, domain)
-        if type(results['domain_uuid']) <> type("") and type(results['domain_uuid']) <> type(u""):
+        if not isinstance(results['domain_uuid'], str) and not isinstance(results['domain_uuid'], unicode):
             raise (TypeError("string", repr(results['domain_uuid'])))
         if results['implementation'][0] == 'Blkback':
-            if type(results['implementation'][1]) <> type("") and type(results['implementation'][1]) <> type(u""):
+            if not isinstance(results['implementation'][1], str) and not isinstance(results['implementation'][1], unicode):
                 raise (TypeError("string", repr(results['implementation'][1])))
         elif results['implementation'][0] == 'Tapdisk3':
-            if type(results['implementation'][1]) <> type("") and type(results['implementation'][1]) <> type(u""):
+            if not isinstance(results['implementation'][1], str) and not isinstance(results['implementation'][1], unicode):
                 raise (TypeError("string", repr(results['implementation'][1])))
         elif results['implementation'][0] == 'Qdisk':
-            if type(results['implementation'][1]) <> type("") and type(results['implementation'][1]) <> type(u""):
+            if not isinstance(results['implementation'][1], str) and not isinstance(results['implementation'][1], unicode):
                 raise (TypeError("string", repr(results['implementation'][1])))
         return results
     def activate(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('uri')):
+        if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
-        if type(uri) <> type("") and type(uri) <> type(u""):
+        if not isinstance(uri, str) and not isinstance(uri, unicode):
             raise (TypeError("string", repr(uri)))
-        if not(args.has_key('domain')):
+        if not('domain' in args):
             raise UnmarshalException('argument missing', 'domain', '')
         domain = args["domain"]
-        if type(domain) <> type("") and type(domain) <> type(u""):
+        if not isinstance(domain, str) and not isinstance(domain, unicode):
             raise (TypeError("string", repr(domain)))
         results = self._impl.activate(dbg, uri, domain)
         return results
     def deactivate(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('uri')):
+        if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
-        if type(uri) <> type("") and type(uri) <> type(u""):
+        if not isinstance(uri, str) and not isinstance(uri, unicode):
             raise (TypeError("string", repr(uri)))
-        if not(args.has_key('domain')):
+        if not('domain' in args):
             raise UnmarshalException('argument missing', 'domain', '')
         domain = args["domain"]
-        if type(domain) <> type("") and type(domain) <> type(u""):
+        if not isinstance(domain, str) and not isinstance(domain, unicode):
             raise (TypeError("string", repr(domain)))
         results = self._impl.deactivate(dbg, uri, domain)
         return results
     def detach(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('uri')):
+        if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
-        if type(uri) <> type("") and type(uri) <> type(u""):
+        if not isinstance(uri, str) and not isinstance(uri, unicode):
             raise (TypeError("string", repr(uri)))
-        if not(args.has_key('domain')):
+        if not('domain' in args):
             raise UnmarshalException('argument missing', 'domain', '')
         domain = args["domain"]
-        if type(domain) <> type("") and type(domain) <> type(u""):
+        if not isinstance(domain, str) and not isinstance(domain, unicode):
             raise (TypeError("string", repr(domain)))
         results = self._impl.detach(dbg, uri, domain)
         return results
     def close(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('uri')):
+        if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
-        if type(uri) <> type("") and type(uri) <> type(u""):
+        if not isinstance(uri, str) and not isinstance(uri, unicode):
             raise (TypeError("string", repr(uri)))
         results = self._impl.close(dbg, uri)
         return results
@@ -209,8 +214,6 @@ class Datapath_test:
         """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
         result = {}
         return result
-import argparse, traceback
-import xapi
 class Datapath_commandline():
     """Parse command-line arguments and call an implementation."""
     def __init__(self, impl):
@@ -227,7 +230,7 @@ class Datapath_commandline():
         parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
         parser.add_argument('dbg', action='store', help='Debug context from the caller')
         parser.add_argument('uri', action='store', help='A URI which represents how to access the volume disk data.')
-        parser.add_argument('persistent', action='store', help='True means the disk data is persistent and should be preserved when the datapath is closed i.e. when a VM is shutdown or rebooted. False means the data should be thrown away when the VM is shutdown or rebooted.')
+        parser.add_argument('--persistent', action='store_true', help='True means the disk data is persistent and should be preserved when the datapath is closed i.e. when a VM is shutdown or rebooted. False means the data should be thrown away when the VM is shutdown or rebooted.')
         return vars(parser.parse_args())
     def _parse_attach(self):
         """[attach uri domain] prepares a connection between the storage named by [uri] and the Xen domain with id [domain]. The return value is the information needed by the Xen toolstack to setup the shared-memory blkfront protocol. Note that the same volume may be simultaneously attached to multiple hosts for example over a migrate. If an implementation needs to perform an explicit handover, then it should implement [activate] and [deactivate]. This function is idempotent."""
@@ -373,22 +376,22 @@ class Datapath_commandline():
                 raise e
 class datapath_server_dispatcher:
     """Demux calls to individual interface server_dispatchers"""
-    def __init__(self, Datapath = None):
+    def __init__(self, Datapath=None):
         self.Datapath = Datapath
     def _dispatch(self, method, params):
         try:
-            log("method = %s params = %s" % (method, repr(params)))
+            logging.debug("method = %s params = %s" % (method, repr(params)))
             if method.startswith("Datapath") and self.Datapath:
                 return self.Datapath._dispatch(method, params)
             raise UnknownMethod(method)
         except Exception, e:
-            log("caught %s" % e)
+            logging.info("caught %s" % e)
             traceback.print_exc()
             try:
                 # A declared (expected) failure will have a .failure() method
-                log("returning %s" % (repr(e.failure())))
+                logging.debug("returning %s" % (repr(e.failure())))
                 return e.failure()
-            except:
+            except AttributeError:
                 # An undeclared (unexpected) failure is wrapped as InternalError
                 return (InternalError(str(e)).failure())
 class datapath_server_test(datapath_server_dispatcher):

--- a/python/xapi/storage/api/datapath.py
+++ b/python/xapi/storage/api/datapath.py
@@ -1,0 +1,397 @@
+from xapi import *
+import traceback
+class Unimplemented(Rpc_light_failure):
+    def __init__(self, arg_0):
+        Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])
+        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+            raise (TypeError("string", repr(arg_0)))
+        self.arg_0 = arg_0
+class Datapath_server_dispatcher:
+    """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+    def __init__(self, impl):
+        """impl is a proxy object whose methods contain the implementation"""
+        self._impl = impl
+    def open(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('uri')):
+            raise UnmarshalException('argument missing', 'uri', '')
+        uri = args["uri"]
+        if type(uri) <> type("") and type(uri) <> type(u""):
+            raise (TypeError("string", repr(uri)))
+        if not(args.has_key('persistent')):
+            raise UnmarshalException('argument missing', 'persistent', '')
+        persistent = args["persistent"]
+        if type(persistent) <> type(True):
+            raise (TypeError("bool", repr(persistent)))
+        results = self._impl.open(dbg, uri, persistent)
+        return results
+    def attach(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('uri')):
+            raise UnmarshalException('argument missing', 'uri', '')
+        uri = args["uri"]
+        if type(uri) <> type("") and type(uri) <> type(u""):
+            raise (TypeError("string", repr(uri)))
+        if not(args.has_key('domain')):
+            raise UnmarshalException('argument missing', 'domain', '')
+        domain = args["domain"]
+        if type(domain) <> type("") and type(domain) <> type(u""):
+            raise (TypeError("string", repr(domain)))
+        results = self._impl.attach(dbg, uri, domain)
+        if type(results['domain_uuid']) <> type("") and type(results['domain_uuid']) <> type(u""):
+            raise (TypeError("string", repr(results['domain_uuid'])))
+        if results['implementation'][0] == 'Blkback':
+            if type(results['implementation'][1]) <> type("") and type(results['implementation'][1]) <> type(u""):
+                raise (TypeError("string", repr(results['implementation'][1])))
+        elif results['implementation'][0] == 'Tapdisk3':
+            if type(results['implementation'][1]) <> type("") and type(results['implementation'][1]) <> type(u""):
+                raise (TypeError("string", repr(results['implementation'][1])))
+        elif results['implementation'][0] == 'Qdisk':
+            if type(results['implementation'][1]) <> type("") and type(results['implementation'][1]) <> type(u""):
+                raise (TypeError("string", repr(results['implementation'][1])))
+        return results
+    def activate(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('uri')):
+            raise UnmarshalException('argument missing', 'uri', '')
+        uri = args["uri"]
+        if type(uri) <> type("") and type(uri) <> type(u""):
+            raise (TypeError("string", repr(uri)))
+        if not(args.has_key('domain')):
+            raise UnmarshalException('argument missing', 'domain', '')
+        domain = args["domain"]
+        if type(domain) <> type("") and type(domain) <> type(u""):
+            raise (TypeError("string", repr(domain)))
+        results = self._impl.activate(dbg, uri, domain)
+        return results
+    def deactivate(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('uri')):
+            raise UnmarshalException('argument missing', 'uri', '')
+        uri = args["uri"]
+        if type(uri) <> type("") and type(uri) <> type(u""):
+            raise (TypeError("string", repr(uri)))
+        if not(args.has_key('domain')):
+            raise UnmarshalException('argument missing', 'domain', '')
+        domain = args["domain"]
+        if type(domain) <> type("") and type(domain) <> type(u""):
+            raise (TypeError("string", repr(domain)))
+        results = self._impl.deactivate(dbg, uri, domain)
+        return results
+    def detach(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('uri')):
+            raise UnmarshalException('argument missing', 'uri', '')
+        uri = args["uri"]
+        if type(uri) <> type("") and type(uri) <> type(u""):
+            raise (TypeError("string", repr(uri)))
+        if not(args.has_key('domain')):
+            raise UnmarshalException('argument missing', 'domain', '')
+        domain = args["domain"]
+        if type(domain) <> type("") and type(domain) <> type(u""):
+            raise (TypeError("string", repr(domain)))
+        results = self._impl.detach(dbg, uri, domain)
+        return results
+    def close(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('uri')):
+            raise UnmarshalException('argument missing', 'uri', '')
+        uri = args["uri"]
+        if type(uri) <> type("") and type(uri) <> type(u""):
+            raise (TypeError("string", repr(uri)))
+        results = self._impl.close(dbg, uri)
+        return results
+    def _dispatch(self, method, params):
+        """type check inputs, call implementation, type check outputs and return"""
+        args = params[0]
+        if method == "Datapath.open":
+            return success(self.open(args))
+        elif method == "Datapath.attach":
+            return success(self.attach(args))
+        elif method == "Datapath.activate":
+            return success(self.activate(args))
+        elif method == "Datapath.deactivate":
+            return success(self.deactivate(args))
+        elif method == "Datapath.detach":
+            return success(self.detach(args))
+        elif method == "Datapath.close":
+            return success(self.close(args))
+class Datapath_skeleton:
+    """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+    def __init__(self):
+        pass
+    def open(self, dbg, uri, persistent):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        raise Unimplemented("Datapath.open")
+    def attach(self, dbg, uri, domain):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        raise Unimplemented("Datapath.attach")
+    def activate(self, dbg, uri, domain):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        raise Unimplemented("Datapath.activate")
+    def deactivate(self, dbg, uri, domain):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        raise Unimplemented("Datapath.deactivate")
+    def detach(self, dbg, uri, domain):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        raise Unimplemented("Datapath.detach")
+    def close(self, dbg, uri):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        raise Unimplemented("Datapath.close")
+class Datapath_test:
+    """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+    def __init__(self):
+        pass
+    def open(self, dbg, uri, persistent):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        result = {}
+        return result
+    def attach(self, dbg, uri, domain):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        result = {}
+        result["backend"] = { "domain_uuid": "string", "implementation": None }
+        return result
+    def activate(self, dbg, uri, domain):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        result = {}
+        return result
+    def deactivate(self, dbg, uri, domain):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        result = {}
+        return result
+    def detach(self, dbg, uri, domain):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        result = {}
+        return result
+    def close(self, dbg, uri):
+        """Xapi will call the functions here on VM start/shutdown/suspend/resume/migrate. Every function is idempotent. Every function takes a domain parameter which allows the implementation to track how many domains are currently using the volume."""
+        result = {}
+        return result
+import argparse, traceback
+import xapi
+class Datapath_commandline():
+    """Parse command-line arguments and call an implementation."""
+    def __init__(self, impl):
+        self.impl = impl
+        self.dispatcher = Datapath_server_dispatcher(self.impl)
+    def _parse_open(self):
+        """[open uri persistent] is called before a disk is attached to a VM. If persistent is true then care should be taken to persist all writes to the disk. If persistent is false then the implementation should configure a temporary location for writes so they can be thrown away on [close]."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[open uri persistent] is called before a disk is attached to a VM. If persistent is true then care should be taken to persist all writes to the disk. If persistent is false then the implementation should configure a temporary location for writes so they can be thrown away on [close].')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('uri', action='store', help='A URI which represents how to access the volume disk data.')
+        parser.add_argument('persistent', action='store', help='True means the disk data is persistent and should be preserved when the datapath is closed i.e. when a VM is shutdown or rebooted. False means the data should be thrown away when the VM is shutdown or rebooted.')
+        return vars(parser.parse_args())
+    def _parse_attach(self):
+        """[attach uri domain] prepares a connection between the storage named by [uri] and the Xen domain with id [domain]. The return value is the information needed by the Xen toolstack to setup the shared-memory blkfront protocol. Note that the same volume may be simultaneously attached to multiple hosts for example over a migrate. If an implementation needs to perform an explicit handover, then it should implement [activate] and [deactivate]. This function is idempotent."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[attach uri domain] prepares a connection between the storage named by [uri] and the Xen domain with id [domain]. The return value is the information needed by the Xen toolstack to setup the shared-memory blkfront protocol. Note that the same volume may be simultaneously attached to multiple hosts for example over a migrate. If an implementation needs to perform an explicit handover, then it should implement [activate] and [deactivate]. This function is idempotent.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('uri', action='store', help='A URI which represents how to access the volume disk data.')
+        parser.add_argument('domain', action='store', help='An opaque string which represents the Xen domain.')
+        return vars(parser.parse_args())
+    def _parse_activate(self):
+        """[activate uri domain] is called just before a VM needs to read or write its disk. This is an opportunity for an implementation which needs to perform an explicit volume handover to do it. This function is called in the migration downtime window so delays here will be noticeable to users and should be minimised. This function is idempotent."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[activate uri domain] is called just before a VM needs to read or write its disk. This is an opportunity for an implementation which needs to perform an explicit volume handover to do it. This function is called in the migration downtime window so delays here will be noticeable to users and should be minimised. This function is idempotent.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('uri', action='store', help='A URI which represents how to access the volume disk data.')
+        parser.add_argument('domain', action='store', help='An opaque string which represents the Xen domain.')
+        return vars(parser.parse_args())
+    def _parse_deactivate(self):
+        """[deactivate uri domain] is called as soon as a VM has finished reading or writing its disk. This is an opportunity for an implementation which needs to perform an explicit volume handover to do it. This function is called in the migration downtime window so delays here will be noticeable to users and should be minimised. This function is idempotent."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[deactivate uri domain] is called as soon as a VM has finished reading or writing its disk. This is an opportunity for an implementation which needs to perform an explicit volume handover to do it. This function is called in the migration downtime window so delays here will be noticeable to users and should be minimised. This function is idempotent.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('uri', action='store', help='A URI which represents how to access the volume disk data.')
+        parser.add_argument('domain', action='store', help='An opaque string which represents the Xen domain.')
+        return vars(parser.parse_args())
+    def _parse_detach(self):
+        """[detach uri domain] is called sometime after a VM has finished reading or writing its disk. This is an opportunity to clean up any resources associated with the disk. This function is called outside the migration downtime window so can be slow without affecting users. This function is idempotent. This function should never fail. If an implementation is unable to perform some cleanup right away then it should queue the action internally. Any error result represents a bug in the implementation."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[detach uri domain] is called sometime after a VM has finished reading or writing its disk. This is an opportunity to clean up any resources associated with the disk. This function is called outside the migration downtime window so can be slow without affecting users. This function is idempotent. This function should never fail. If an implementation is unable to perform some cleanup right away then it should queue the action internally. Any error result represents a bug in the implementation.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('uri', action='store', help='A URI which represents how to access the volume disk data.')
+        parser.add_argument('domain', action='store', help='An opaque string which represents the Xen domain.')
+        return vars(parser.parse_args())
+    def _parse_close(self):
+        """[close uri] is called after a disk is detached and a VM shutdown. This is an opportunity to throw away writes if the disk is not persistent."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[close uri] is called after a disk is detached and a VM shutdown. This is an opportunity to throw away writes if the disk is not persistent.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('uri', action='store', help='A URI which represents how to access the volume disk data.')
+        return vars(parser.parse_args())
+    def open(self):
+        use_json = False
+        try:
+            request = self._parse_open()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.open(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def attach(self):
+        use_json = False
+        try:
+            request = self._parse_attach()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.attach(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def activate(self):
+        use_json = False
+        try:
+            request = self._parse_activate()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.activate(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def deactivate(self):
+        use_json = False
+        try:
+            request = self._parse_deactivate()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.deactivate(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def detach(self):
+        use_json = False
+        try:
+            request = self._parse_detach()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.detach(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def close(self):
+        use_json = False
+        try:
+            request = self._parse_close()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.close(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+class datapath_server_dispatcher:
+    """Demux calls to individual interface server_dispatchers"""
+    def __init__(self, Datapath = None):
+        self.Datapath = Datapath
+    def _dispatch(self, method, params):
+        try:
+            log("method = %s params = %s" % (method, repr(params)))
+            if method.startswith("Datapath") and self.Datapath:
+                return self.Datapath._dispatch(method, params)
+            raise UnknownMethod(method)
+        except Exception, e:
+            log("caught %s" % e)
+            traceback.print_exc()
+            try:
+                # A declared (expected) failure will have a .failure() method
+                log("returning %s" % (repr(e.failure())))
+                return e.failure()
+            except:
+                # An undeclared (unexpected) failure is wrapped as InternalError
+                return (InternalError(str(e)).failure())
+class datapath_server_test(datapath_server_dispatcher):
+    """Create a server which will respond to all calls, returning arbitrary values. This is intended as a marshal/unmarshal test."""
+    def __init__(self):
+        datapath_server_dispatcher.__init__(self, Datapath_server_dispatcher(Datapath_test()))

--- a/python/xapi/storage/api/plugin.py
+++ b/python/xapi/storage/api/plugin.py
@@ -1,9 +1,14 @@
-from xapi import *
+from xapi import success, Rpc_light_failure, InternalError, UnmarshalException, TypeError, is_long, UnknownMethod
+import xapi
+import sys
+import json
+import argparse
 import traceback
+import logging
 class Unimplemented(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])
-        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+        if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
             raise (TypeError("string", repr(arg_0)))
         self.arg_0 = arg_0
 class Plugin_server_dispatcher:
@@ -13,74 +18,74 @@ class Plugin_server_dispatcher:
         self._impl = impl
     def query(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
         results = self._impl.query(dbg)
-        if type(results['plugin']) <> type("") and type(results['plugin']) <> type(u""):
+        if not isinstance(results['plugin'], str) and not isinstance(results['plugin'], unicode):
             raise (TypeError("string", repr(results['plugin'])))
-        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+        if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
             raise (TypeError("string", repr(results['name'])))
-        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+        if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
             raise (TypeError("string", repr(results['description'])))
-        if type(results['vendor']) <> type("") and type(results['vendor']) <> type(u""):
+        if not isinstance(results['vendor'], str) and not isinstance(results['vendor'], unicode):
             raise (TypeError("string", repr(results['vendor'])))
-        if type(results['copyright']) <> type("") and type(results['copyright']) <> type(u""):
+        if not isinstance(results['copyright'], str) and not isinstance(results['copyright'], unicode):
             raise (TypeError("string", repr(results['copyright'])))
-        if type(results['version']) <> type("") and type(results['version']) <> type(u""):
+        if not isinstance(results['version'], str) and not isinstance(results['version'], unicode):
             raise (TypeError("string", repr(results['version'])))
-        if type(results['required_api_version']) <> type("") and type(results['required_api_version']) <> type(u""):
+        if not isinstance(results['required_api_version'], str) and not isinstance(results['required_api_version'], unicode):
             raise (TypeError("string", repr(results['required_api_version'])))
-        if type(results['features']) <> type([]):
+        if not isinstance(results['features'], list):
             raise (TypeError("string list", repr(results['features'])))
         for tmp_1 in results['features']:
-            if type(tmp_1) <> type("") and type(tmp_1) <> type(u""):
+            if not isinstance(tmp_1, str) and not isinstance(tmp_1, unicode):
                 raise (TypeError("string", repr(tmp_1)))
-        if type(results['configuration']) <> type({}):
+        if not isinstance(results['configuration'], dict):
             raise (TypeError("(string * string) list", repr(results['configuration'])))
         for tmp_2 in results['configuration'].keys():
-            if type(tmp_2) <> type("") and type(tmp_2) <> type(u""):
+            if not isinstance(tmp_2, str) and not isinstance(tmp_2, unicode):
                 raise (TypeError("string", repr(tmp_2)))
         for tmp_2 in results['configuration'].values():
-            if type(tmp_2) <> type("") and type(tmp_2) <> type(u""):
+            if not isinstance(tmp_2, str) and not isinstance(tmp_2, unicode):
                 raise (TypeError("string", repr(tmp_2)))
-        if type(results['required_cluster_stack']) <> type([]):
+        if not isinstance(results['required_cluster_stack'], list):
             raise (TypeError("string list", repr(results['required_cluster_stack'])))
         for tmp_3 in results['required_cluster_stack']:
-            if type(tmp_3) <> type("") and type(tmp_3) <> type(u""):
+            if not isinstance(tmp_3, str) and not isinstance(tmp_3, unicode):
                 raise (TypeError("string", repr(tmp_3)))
         return results
     def ls(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
         results = self._impl.ls(dbg)
-        if type(results) <> type([]):
+        if not isinstance(results, list):
             raise (TypeError("string list", repr(results)))
         for tmp_4 in results:
-            if type(tmp_4) <> type("") and type(tmp_4) <> type(u""):
+            if not isinstance(tmp_4, str) and not isinstance(tmp_4, unicode):
                 raise (TypeError("string", repr(tmp_4)))
         return results
     def diagnostics(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
         results = self._impl.diagnostics(dbg)
-        if type(results) <> type("") and type(results) <> type(u""):
+        if not isinstance(results, str) and not isinstance(results, unicode):
             raise (TypeError("string", repr(results)))
         return results
     def _dispatch(self, method, params):
@@ -124,8 +129,6 @@ class Plugin_test:
         result = {}
         result["diagnostics"] = "string"
         return result
-import argparse, traceback
-import xapi
 class Plugin_commandline():
     """Parse command-line arguments and call an implementation."""
     def __init__(self, impl):
@@ -205,22 +208,22 @@ class Plugin_commandline():
                 raise e
 class plugin_server_dispatcher:
     """Demux calls to individual interface server_dispatchers"""
-    def __init__(self, Plugin = None):
+    def __init__(self, Plugin=None):
         self.Plugin = Plugin
     def _dispatch(self, method, params):
         try:
-            log("method = %s params = %s" % (method, repr(params)))
+            logging.debug("method = %s params = %s" % (method, repr(params)))
             if method.startswith("Plugin") and self.Plugin:
                 return self.Plugin._dispatch(method, params)
             raise UnknownMethod(method)
         except Exception, e:
-            log("caught %s" % e)
+            logging.info("caught %s" % e)
             traceback.print_exc()
             try:
                 # A declared (expected) failure will have a .failure() method
-                log("returning %s" % (repr(e.failure())))
+                logging.debug("returning %s" % (repr(e.failure())))
                 return e.failure()
-            except:
+            except AttributeError:
                 # An undeclared (unexpected) failure is wrapped as InternalError
                 return (InternalError(str(e)).failure())
 class plugin_server_test(plugin_server_dispatcher):

--- a/python/xapi/storage/api/plugin.py
+++ b/python/xapi/storage/api/plugin.py
@@ -1,0 +1,229 @@
+from xapi import *
+import traceback
+class Unimplemented(Rpc_light_failure):
+    def __init__(self, arg_0):
+        Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])
+        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+            raise (TypeError("string", repr(arg_0)))
+        self.arg_0 = arg_0
+class Plugin_server_dispatcher:
+    """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
+    def __init__(self, impl):
+        """impl is a proxy object whose methods contain the implementation"""
+        self._impl = impl
+    def query(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        results = self._impl.query(dbg)
+        if type(results['plugin']) <> type("") and type(results['plugin']) <> type(u""):
+            raise (TypeError("string", repr(results['plugin'])))
+        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+            raise (TypeError("string", repr(results['name'])))
+        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+            raise (TypeError("string", repr(results['description'])))
+        if type(results['vendor']) <> type("") and type(results['vendor']) <> type(u""):
+            raise (TypeError("string", repr(results['vendor'])))
+        if type(results['copyright']) <> type("") and type(results['copyright']) <> type(u""):
+            raise (TypeError("string", repr(results['copyright'])))
+        if type(results['version']) <> type("") and type(results['version']) <> type(u""):
+            raise (TypeError("string", repr(results['version'])))
+        if type(results['required_api_version']) <> type("") and type(results['required_api_version']) <> type(u""):
+            raise (TypeError("string", repr(results['required_api_version'])))
+        if type(results['features']) <> type([]):
+            raise (TypeError("string list", repr(results['features'])))
+        for tmp_1 in results['features']:
+            if type(tmp_1) <> type("") and type(tmp_1) <> type(u""):
+                raise (TypeError("string", repr(tmp_1)))
+        if type(results['configuration']) <> type({}):
+            raise (TypeError("(string * string) list", repr(results['configuration'])))
+        for tmp_2 in results['configuration'].keys():
+            if type(tmp_2) <> type("") and type(tmp_2) <> type(u""):
+                raise (TypeError("string", repr(tmp_2)))
+        for tmp_2 in results['configuration'].values():
+            if type(tmp_2) <> type("") and type(tmp_2) <> type(u""):
+                raise (TypeError("string", repr(tmp_2)))
+        if type(results['required_cluster_stack']) <> type([]):
+            raise (TypeError("string list", repr(results['required_cluster_stack'])))
+        for tmp_3 in results['required_cluster_stack']:
+            if type(tmp_3) <> type("") and type(tmp_3) <> type(u""):
+                raise (TypeError("string", repr(tmp_3)))
+        return results
+    def ls(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        results = self._impl.ls(dbg)
+        if type(results) <> type([]):
+            raise (TypeError("string list", repr(results)))
+        for tmp_4 in results:
+            if type(tmp_4) <> type("") and type(tmp_4) <> type(u""):
+                raise (TypeError("string", repr(tmp_4)))
+        return results
+    def diagnostics(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        results = self._impl.diagnostics(dbg)
+        if type(results) <> type("") and type(results) <> type(u""):
+            raise (TypeError("string", repr(results)))
+        return results
+    def _dispatch(self, method, params):
+        """type check inputs, call implementation, type check outputs and return"""
+        args = params[0]
+        if method == "Plugin.query":
+            return success(self.query(args))
+        elif method == "Plugin.ls":
+            return success(self.ls(args))
+        elif method == "Plugin.diagnostics":
+            return success(self.diagnostics(args))
+class Plugin_skeleton:
+    """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
+    def __init__(self):
+        pass
+    def query(self, dbg):
+        """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
+        raise Unimplemented("Plugin.query")
+    def ls(self, dbg):
+        """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
+        raise Unimplemented("Plugin.ls")
+    def diagnostics(self, dbg):
+        """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
+        raise Unimplemented("Plugin.diagnostics")
+class Plugin_test:
+    """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
+    def __init__(self):
+        pass
+    def query(self, dbg):
+        """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
+        result = {}
+        result["query_result"] = { "plugin": "string", "name": "string", "description": "string", "vendor": "string", "copyright": "string", "version": "string", "required_api_version": "string", "features": [ "string", "string" ], "configuration": { "string": "string" }, "required_cluster_stack": [ "string", "string" ] }
+        return result
+    def ls(self, dbg):
+        """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
+        result = {}
+        result["srs"] = [ "string", "string" ]
+        return result
+    def diagnostics(self, dbg):
+        """Discover properties of this implementation. Every implementation  must support the query interface or it will not be recognised as  a storage plugin by xapi."""
+        result = {}
+        result["diagnostics"] = "string"
+        return result
+import argparse, traceback
+import xapi
+class Plugin_commandline():
+    """Parse command-line arguments and call an implementation."""
+    def __init__(self, impl):
+        self.impl = impl
+        self.dispatcher = Plugin_server_dispatcher(self.impl)
+    def _parse_query(self):
+        """Query this implementation and return its properties. This is  called by xapi to determine whether it is compatible with xapi  and to discover the supported features."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='Query this implementation and return its properties. This is  called by xapi to determine whether it is compatible with xapi  and to discover the supported features.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        return vars(parser.parse_args())
+    def _parse_ls(self):
+        """[ls dbg]: returns a list of attached SRs"""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[ls dbg]: returns a list of attached SRs')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        return vars(parser.parse_args())
+    def _parse_diagnostics(self):
+        """Returns a printable set of backend diagnostic information. Implementations are encouraged to include any data which will  be useful to diagnose problems. Note this data should not  include personally-identifiable data as it is intended to be  automatically included in bug reports."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='Returns a printable set of backend diagnostic information. Implementations are encouraged to include any data which will  be useful to diagnose problems. Note this data should not  include personally-identifiable data as it is intended to be  automatically included in bug reports.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        return vars(parser.parse_args())
+    def query(self):
+        use_json = False
+        try:
+            request = self._parse_query()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.query(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def ls(self):
+        use_json = False
+        try:
+            request = self._parse_ls()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.ls(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def diagnostics(self):
+        use_json = False
+        try:
+            request = self._parse_diagnostics()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.diagnostics(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+class plugin_server_dispatcher:
+    """Demux calls to individual interface server_dispatchers"""
+    def __init__(self, Plugin = None):
+        self.Plugin = Plugin
+    def _dispatch(self, method, params):
+        try:
+            log("method = %s params = %s" % (method, repr(params)))
+            if method.startswith("Plugin") and self.Plugin:
+                return self.Plugin._dispatch(method, params)
+            raise UnknownMethod(method)
+        except Exception, e:
+            log("caught %s" % e)
+            traceback.print_exc()
+            try:
+                # A declared (expected) failure will have a .failure() method
+                log("returning %s" % (repr(e.failure())))
+                return e.failure()
+            except:
+                # An undeclared (unexpected) failure is wrapped as InternalError
+                return (InternalError(str(e)).failure())
+class plugin_server_test(plugin_server_dispatcher):
+    """Create a server which will respond to all calls, returning arbitrary values. This is intended as a marshal/unmarshal test."""
+    def __init__(self):
+        plugin_server_dispatcher.__init__(self, Plugin_server_dispatcher(Plugin_test()))

--- a/python/xapi/storage/api/v4/__init__.py
+++ b/python/xapi/storage/api/v4/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python

--- a/python/xapi/storage/api/volume.py
+++ b/python/xapi/storage/api/volume.py
@@ -1,33 +1,38 @@
-from xapi import *
+from xapi import success, Rpc_light_failure, InternalError, UnmarshalException, TypeError, is_long, UnknownMethod
+import xapi
+import sys
+import json
+import argparse
 import traceback
+import logging
 class Sr_not_attached(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Sr_not_attached", [ arg_0 ])
-        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+        if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
             raise (TypeError("string", repr(arg_0)))
         self.arg_0 = arg_0
 class SR_does_not_exist(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "SR_does_not_exist", [ arg_0 ])
-        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+        if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
             raise (TypeError("string", repr(arg_0)))
         self.arg_0 = arg_0
 class Volume_does_not_exist(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Volume_does_not_exist", [ arg_0 ])
-        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+        if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
             raise (TypeError("string", repr(arg_0)))
         self.arg_0 = arg_0
 class Unimplemented(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])
-        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+        if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
             raise (TypeError("string", repr(arg_0)))
         self.arg_0 = arg_0
 class Cancelled(Rpc_light_failure):
     def __init__(self, arg_0):
         Rpc_light_failure.__init__(self, "Cancelled", [ arg_0 ])
-        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+        if not isinstance(arg_0, str) and not isinstance(arg_0, unicode):
             raise (TypeError("string", repr(arg_0)))
         self.arg_0 = arg_0
 class Volume_server_dispatcher:
@@ -37,311 +42,311 @@ class Volume_server_dispatcher:
         self._impl = impl
     def create(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('name')):
+        if not('name' in args):
             raise UnmarshalException('argument missing', 'name', '')
         name = args["name"]
-        if type(name) <> type("") and type(name) <> type(u""):
+        if not isinstance(name, str) and not isinstance(name, unicode):
             raise (TypeError("string", repr(name)))
-        if not(args.has_key('description')):
+        if not('description' in args):
             raise UnmarshalException('argument missing', 'description', '')
         description = args["description"]
-        if type(description) <> type("") and type(description) <> type(u""):
+        if not isinstance(description, str) and not isinstance(description, unicode):
             raise (TypeError("string", repr(description)))
-        if not(args.has_key('size')):
+        if not('size' in args):
             raise UnmarshalException('argument missing', 'size', '')
         size = args["size"]
         if not(is_long(size)):
             raise (TypeError("int64", repr(size)))
         results = self._impl.create(dbg, sr, name, description, size)
-        if type(results['key']) <> type("") and type(results['key']) <> type(u""):
+        if not isinstance(results['key'], str) and not isinstance(results['key'], unicode):
             raise (TypeError("string", repr(results['key'])))
-        if results['uuid'] <> None:
-            if type(results['uuid']) <> type("") and type(results['uuid']) <> type(u""):
+        if results['uuid'] is not None:
+            if not isinstance(results['uuid'], str) and not isinstance(results['uuid'], unicode):
                 raise (TypeError("string", repr(results['uuid'])))
-        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+        if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
             raise (TypeError("string", repr(results['name'])))
-        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+        if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
             raise (TypeError("string", repr(results['description'])))
-        if type(results['read_write']) <> type(True):
+        if not isinstance(results['read_write'], bool):
             raise (TypeError("bool", repr(results['read_write'])))
         if not(is_long(results['virtual_size'])):
             raise (TypeError("int64", repr(results['virtual_size'])))
         if not(is_long(results['physical_utilisation'])):
             raise (TypeError("int64", repr(results['physical_utilisation'])))
-        if type(results['uri']) <> type([]):
+        if not isinstance(results['uri'], list):
             raise (TypeError("string list", repr(results['uri'])))
         for tmp_5 in results['uri']:
-            if type(tmp_5) <> type("") and type(tmp_5) <> type(u""):
+            if not isinstance(tmp_5, str) and not isinstance(tmp_5, unicode):
                 raise (TypeError("string", repr(tmp_5)))
-        if type(results['keys']) <> type({}):
+        if not isinstance(results['keys'], dict):
             raise (TypeError("(string * string) list", repr(results['keys'])))
         for tmp_6 in results['keys'].keys():
-            if type(tmp_6) <> type("") and type(tmp_6) <> type(u""):
+            if not isinstance(tmp_6, str) and not isinstance(tmp_6, unicode):
                 raise (TypeError("string", repr(tmp_6)))
         for tmp_6 in results['keys'].values():
-            if type(tmp_6) <> type("") and type(tmp_6) <> type(u""):
+            if not isinstance(tmp_6, str) and not isinstance(tmp_6, unicode):
                 raise (TypeError("string", repr(tmp_6)))
         return results
     def snapshot(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('key')):
+        if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
-        if type(key) <> type("") and type(key) <> type(u""):
+        if not isinstance(key, str) and not isinstance(key, unicode):
             raise (TypeError("string", repr(key)))
         results = self._impl.snapshot(dbg, sr, key)
-        if type(results['key']) <> type("") and type(results['key']) <> type(u""):
+        if not isinstance(results['key'], str) and not isinstance(results['key'], unicode):
             raise (TypeError("string", repr(results['key'])))
-        if results['uuid'] <> None:
-            if type(results['uuid']) <> type("") and type(results['uuid']) <> type(u""):
+        if results['uuid'] is not None:
+            if not isinstance(results['uuid'], str) and not isinstance(results['uuid'], unicode):
                 raise (TypeError("string", repr(results['uuid'])))
-        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+        if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
             raise (TypeError("string", repr(results['name'])))
-        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+        if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
             raise (TypeError("string", repr(results['description'])))
-        if type(results['read_write']) <> type(True):
+        if not isinstance(results['read_write'], bool):
             raise (TypeError("bool", repr(results['read_write'])))
         if not(is_long(results['virtual_size'])):
             raise (TypeError("int64", repr(results['virtual_size'])))
         if not(is_long(results['physical_utilisation'])):
             raise (TypeError("int64", repr(results['physical_utilisation'])))
-        if type(results['uri']) <> type([]):
+        if not isinstance(results['uri'], list):
             raise (TypeError("string list", repr(results['uri'])))
         for tmp_7 in results['uri']:
-            if type(tmp_7) <> type("") and type(tmp_7) <> type(u""):
+            if not isinstance(tmp_7, str) and not isinstance(tmp_7, unicode):
                 raise (TypeError("string", repr(tmp_7)))
-        if type(results['keys']) <> type({}):
+        if not isinstance(results['keys'], dict):
             raise (TypeError("(string * string) list", repr(results['keys'])))
         for tmp_8 in results['keys'].keys():
-            if type(tmp_8) <> type("") and type(tmp_8) <> type(u""):
+            if not isinstance(tmp_8, str) and not isinstance(tmp_8, unicode):
                 raise (TypeError("string", repr(tmp_8)))
         for tmp_8 in results['keys'].values():
-            if type(tmp_8) <> type("") and type(tmp_8) <> type(u""):
+            if not isinstance(tmp_8, str) and not isinstance(tmp_8, unicode):
                 raise (TypeError("string", repr(tmp_8)))
         return results
     def clone(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('key')):
+        if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
-        if type(key) <> type("") and type(key) <> type(u""):
+        if not isinstance(key, str) and not isinstance(key, unicode):
             raise (TypeError("string", repr(key)))
         results = self._impl.clone(dbg, sr, key)
-        if type(results['key']) <> type("") and type(results['key']) <> type(u""):
+        if not isinstance(results['key'], str) and not isinstance(results['key'], unicode):
             raise (TypeError("string", repr(results['key'])))
-        if results['uuid'] <> None:
-            if type(results['uuid']) <> type("") and type(results['uuid']) <> type(u""):
+        if results['uuid'] is not None:
+            if not isinstance(results['uuid'], str) and not isinstance(results['uuid'], unicode):
                 raise (TypeError("string", repr(results['uuid'])))
-        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+        if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
             raise (TypeError("string", repr(results['name'])))
-        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+        if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
             raise (TypeError("string", repr(results['description'])))
-        if type(results['read_write']) <> type(True):
+        if not isinstance(results['read_write'], bool):
             raise (TypeError("bool", repr(results['read_write'])))
         if not(is_long(results['virtual_size'])):
             raise (TypeError("int64", repr(results['virtual_size'])))
         if not(is_long(results['physical_utilisation'])):
             raise (TypeError("int64", repr(results['physical_utilisation'])))
-        if type(results['uri']) <> type([]):
+        if not isinstance(results['uri'], list):
             raise (TypeError("string list", repr(results['uri'])))
         for tmp_9 in results['uri']:
-            if type(tmp_9) <> type("") and type(tmp_9) <> type(u""):
+            if not isinstance(tmp_9, str) and not isinstance(tmp_9, unicode):
                 raise (TypeError("string", repr(tmp_9)))
-        if type(results['keys']) <> type({}):
+        if not isinstance(results['keys'], dict):
             raise (TypeError("(string * string) list", repr(results['keys'])))
         for tmp_10 in results['keys'].keys():
-            if type(tmp_10) <> type("") and type(tmp_10) <> type(u""):
+            if not isinstance(tmp_10, str) and not isinstance(tmp_10, unicode):
                 raise (TypeError("string", repr(tmp_10)))
         for tmp_10 in results['keys'].values():
-            if type(tmp_10) <> type("") and type(tmp_10) <> type(u""):
+            if not isinstance(tmp_10, str) and not isinstance(tmp_10, unicode):
                 raise (TypeError("string", repr(tmp_10)))
         return results
     def destroy(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('key')):
+        if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
-        if type(key) <> type("") and type(key) <> type(u""):
+        if not isinstance(key, str) and not isinstance(key, unicode):
             raise (TypeError("string", repr(key)))
         results = self._impl.destroy(dbg, sr, key)
         return results
     def set_name(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('key')):
+        if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
-        if type(key) <> type("") and type(key) <> type(u""):
+        if not isinstance(key, str) and not isinstance(key, unicode):
             raise (TypeError("string", repr(key)))
-        if not(args.has_key('new_name')):
+        if not('new_name' in args):
             raise UnmarshalException('argument missing', 'new_name', '')
         new_name = args["new_name"]
-        if type(new_name) <> type("") and type(new_name) <> type(u""):
+        if not isinstance(new_name, str) and not isinstance(new_name, unicode):
             raise (TypeError("string", repr(new_name)))
         results = self._impl.set_name(dbg, sr, key, new_name)
         return results
     def set_description(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('key')):
+        if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
-        if type(key) <> type("") and type(key) <> type(u""):
+        if not isinstance(key, str) and not isinstance(key, unicode):
             raise (TypeError("string", repr(key)))
-        if not(args.has_key('new_description')):
+        if not('new_description' in args):
             raise UnmarshalException('argument missing', 'new_description', '')
         new_description = args["new_description"]
-        if type(new_description) <> type("") and type(new_description) <> type(u""):
+        if not isinstance(new_description, str) and not isinstance(new_description, unicode):
             raise (TypeError("string", repr(new_description)))
         results = self._impl.set_description(dbg, sr, key, new_description)
         return results
     def set(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('key')):
+        if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
-        if type(key) <> type("") and type(key) <> type(u""):
+        if not isinstance(key, str) and not isinstance(key, unicode):
             raise (TypeError("string", repr(key)))
-        if not(args.has_key('k')):
+        if not('k' in args):
             raise UnmarshalException('argument missing', 'k', '')
         k = args["k"]
-        if type(k) <> type("") and type(k) <> type(u""):
+        if not isinstance(k, str) and not isinstance(k, unicode):
             raise (TypeError("string", repr(k)))
-        if not(args.has_key('v')):
+        if not('v' in args):
             raise UnmarshalException('argument missing', 'v', '')
         v = args["v"]
-        if type(v) <> type("") and type(v) <> type(u""):
+        if not isinstance(v, str) and not isinstance(v, unicode):
             raise (TypeError("string", repr(v)))
         results = self._impl.set(dbg, sr, key, k, v)
         return results
     def unset(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('key')):
+        if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
-        if type(key) <> type("") and type(key) <> type(u""):
+        if not isinstance(key, str) and not isinstance(key, unicode):
             raise (TypeError("string", repr(key)))
-        if not(args.has_key('k')):
+        if not('k' in args):
             raise UnmarshalException('argument missing', 'k', '')
         k = args["k"]
-        if type(k) <> type("") and type(k) <> type(u""):
+        if not isinstance(k, str) and not isinstance(k, unicode):
             raise (TypeError("string", repr(k)))
         results = self._impl.unset(dbg, sr, key, k)
         return results
     def resize(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('key')):
+        if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
-        if type(key) <> type("") and type(key) <> type(u""):
+        if not isinstance(key, str) and not isinstance(key, unicode):
             raise (TypeError("string", repr(key)))
-        if not(args.has_key('new_size')):
+        if not('new_size' in args):
             raise UnmarshalException('argument missing', 'new_size', '')
         new_size = args["new_size"]
         if not(is_long(new_size)):
@@ -350,51 +355,51 @@ class Volume_server_dispatcher:
         return results
     def stat(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('key')):
+        if not('key' in args):
             raise UnmarshalException('argument missing', 'key', '')
         key = args["key"]
-        if type(key) <> type("") and type(key) <> type(u""):
+        if not isinstance(key, str) and not isinstance(key, unicode):
             raise (TypeError("string", repr(key)))
         results = self._impl.stat(dbg, sr, key)
-        if type(results['key']) <> type("") and type(results['key']) <> type(u""):
+        if not isinstance(results['key'], str) and not isinstance(results['key'], unicode):
             raise (TypeError("string", repr(results['key'])))
-        if results['uuid'] <> None:
-            if type(results['uuid']) <> type("") and type(results['uuid']) <> type(u""):
+        if results['uuid'] is not None:
+            if not isinstance(results['uuid'], str) and not isinstance(results['uuid'], unicode):
                 raise (TypeError("string", repr(results['uuid'])))
-        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+        if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
             raise (TypeError("string", repr(results['name'])))
-        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+        if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
             raise (TypeError("string", repr(results['description'])))
-        if type(results['read_write']) <> type(True):
+        if not isinstance(results['read_write'], bool):
             raise (TypeError("bool", repr(results['read_write'])))
         if not(is_long(results['virtual_size'])):
             raise (TypeError("int64", repr(results['virtual_size'])))
         if not(is_long(results['physical_utilisation'])):
             raise (TypeError("int64", repr(results['physical_utilisation'])))
-        if type(results['uri']) <> type([]):
+        if not isinstance(results['uri'], list):
             raise (TypeError("string list", repr(results['uri'])))
         for tmp_11 in results['uri']:
-            if type(tmp_11) <> type("") and type(tmp_11) <> type(u""):
+            if not isinstance(tmp_11, str) and not isinstance(tmp_11, unicode):
                 raise (TypeError("string", repr(tmp_11)))
-        if type(results['keys']) <> type({}):
+        if not isinstance(results['keys'], dict):
             raise (TypeError("(string * string) list", repr(results['keys'])))
         for tmp_12 in results['keys'].keys():
-            if type(tmp_12) <> type("") and type(tmp_12) <> type(u""):
+            if not isinstance(tmp_12, str) and not isinstance(tmp_12, unicode):
                 raise (TypeError("string", repr(tmp_12)))
         for tmp_12 in results['keys'].values():
-            if type(tmp_12) <> type("") and type(tmp_12) <> type(u""):
+            if not isinstance(tmp_12, str) and not isinstance(tmp_12, unicode):
                 raise (TypeError("string", repr(tmp_12)))
         return results
     def _dispatch(self, method, params):
@@ -502,8 +507,6 @@ class Volume_test:
         result = {}
         result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }
         return result
-import argparse, traceback
-import xapi
 class Volume_commandline():
     """Parse command-line arguments and call an implementation."""
     def __init__(self, impl):
@@ -784,264 +787,264 @@ class SR_server_dispatcher:
         self._impl = impl
     def probe(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('uri')):
+        if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
-        if type(uri) <> type("") and type(uri) <> type(u""):
+        if not isinstance(uri, str) and not isinstance(uri, unicode):
             raise (TypeError("string", repr(uri)))
         results = self._impl.probe(dbg, uri)
-        if type(results['srs']) <> type([]):
+        if not isinstance(results['srs'], list):
             raise (TypeError("7 list", repr(results['srs'])))
         for tmp_13 in results['srs']:
-            if type(tmp_13['sr']) <> type("") and type(tmp_13['sr']) <> type(u""):
+            if not isinstance(tmp_13['sr'], str) and not isinstance(tmp_13['sr'], unicode):
                 raise (TypeError("string", repr(tmp_13['sr'])))
-            if type(tmp_13['name']) <> type("") and type(tmp_13['name']) <> type(u""):
+            if not isinstance(tmp_13['name'], str) and not isinstance(tmp_13['name'], unicode):
                 raise (TypeError("string", repr(tmp_13['name'])))
-            if type(tmp_13['description']) <> type("") and type(tmp_13['description']) <> type(u""):
+            if not isinstance(tmp_13['description'], str) and not isinstance(tmp_13['description'], unicode):
                 raise (TypeError("string", repr(tmp_13['description'])))
             if not(is_long(tmp_13['free_space'])):
                 raise (TypeError("int64", repr(tmp_13['free_space'])))
             if not(is_long(tmp_13['total_space'])):
                 raise (TypeError("int64", repr(tmp_13['total_space'])))
-            if type(tmp_13['datasources']) <> type([]):
+            if not isinstance(tmp_13['datasources'], list):
                 raise (TypeError("string list", repr(tmp_13['datasources'])))
             for tmp_14 in tmp_13['datasources']:
-                if type(tmp_14) <> type("") and type(tmp_14) <> type(u""):
+                if not isinstance(tmp_14, str) and not isinstance(tmp_14, unicode):
                     raise (TypeError("string", repr(tmp_14)))
-            if type(tmp_13['clustered']) <> type(True):
+            if not isinstance(tmp_13['clustered'], bool):
                 raise (TypeError("bool", repr(tmp_13['clustered'])))
             if tmp_13['health'][0] == 'Healthy':
-                if type(tmp_13['health'][1]) <> type("") and type(tmp_13['health'][1]) <> type(u""):
+                if not isinstance(tmp_13['health'][1], str) and not isinstance(tmp_13['health'][1], unicode):
                     raise (TypeError("string", repr(tmp_13['health'][1])))
             elif tmp_13['health'][0] == 'Recovering':
-                if type(tmp_13['health'][1]) <> type("") and type(tmp_13['health'][1]) <> type(u""):
+                if not isinstance(tmp_13['health'][1], str) and not isinstance(tmp_13['health'][1], unicode):
                     raise (TypeError("string", repr(tmp_13['health'][1])))
-        if type(results['uris']) <> type([]):
+        if not isinstance(results['uris'], list):
             raise (TypeError("string list", repr(results['uris'])))
         for tmp_15 in results['uris']:
-            if type(tmp_15) <> type("") and type(tmp_15) <> type(u""):
+            if not isinstance(tmp_15, str) and not isinstance(tmp_15, unicode):
                 raise (TypeError("string", repr(tmp_15)))
         return results
     def create(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('uri')):
+        if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
-        if type(uri) <> type("") and type(uri) <> type(u""):
+        if not isinstance(uri, str) and not isinstance(uri, unicode):
             raise (TypeError("string", repr(uri)))
-        if not(args.has_key('name')):
+        if not('name' in args):
             raise UnmarshalException('argument missing', 'name', '')
         name = args["name"]
-        if type(name) <> type("") and type(name) <> type(u""):
+        if not isinstance(name, str) and not isinstance(name, unicode):
             raise (TypeError("string", repr(name)))
-        if not(args.has_key('description')):
+        if not('description' in args):
             raise UnmarshalException('argument missing', 'description', '')
         description = args["description"]
-        if type(description) <> type("") and type(description) <> type(u""):
+        if not isinstance(description, str) and not isinstance(description, unicode):
             raise (TypeError("string", repr(description)))
-        if not(args.has_key('configuration')):
+        if not('configuration' in args):
             raise UnmarshalException('argument missing', 'configuration', '')
         configuration = args["configuration"]
-        if type(configuration) <> type({}):
+        if not isinstance(configuration, dict):
             raise (TypeError("(string * string) list", repr(configuration)))
         for tmp_16 in configuration.keys():
-            if type(tmp_16) <> type("") and type(tmp_16) <> type(u""):
+            if not isinstance(tmp_16, str) and not isinstance(tmp_16, unicode):
                 raise (TypeError("string", repr(tmp_16)))
         for tmp_16 in configuration.values():
-            if type(tmp_16) <> type("") and type(tmp_16) <> type(u""):
+            if not isinstance(tmp_16, str) and not isinstance(tmp_16, unicode):
                 raise (TypeError("string", repr(tmp_16)))
         results = self._impl.create(dbg, uri, name, description, configuration)
         return results
     def attach(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('uri')):
+        if not('uri' in args):
             raise UnmarshalException('argument missing', 'uri', '')
         uri = args["uri"]
-        if type(uri) <> type("") and type(uri) <> type(u""):
+        if not isinstance(uri, str) and not isinstance(uri, unicode):
             raise (TypeError("string", repr(uri)))
         results = self._impl.attach(dbg, uri)
-        if type(results) <> type("") and type(results) <> type(u""):
+        if not isinstance(results, str) and not isinstance(results, unicode):
             raise (TypeError("string", repr(results)))
         return results
     def detach(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
         results = self._impl.detach(dbg, sr)
         return results
     def destroy(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
         results = self._impl.destroy(dbg, sr)
         return results
     def stat(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
         results = self._impl.stat(dbg, sr)
-        if type(results['sr']) <> type("") and type(results['sr']) <> type(u""):
+        if not isinstance(results['sr'], str) and not isinstance(results['sr'], unicode):
             raise (TypeError("string", repr(results['sr'])))
-        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+        if not isinstance(results['name'], str) and not isinstance(results['name'], unicode):
             raise (TypeError("string", repr(results['name'])))
-        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+        if not isinstance(results['description'], str) and not isinstance(results['description'], unicode):
             raise (TypeError("string", repr(results['description'])))
         if not(is_long(results['free_space'])):
             raise (TypeError("int64", repr(results['free_space'])))
         if not(is_long(results['total_space'])):
             raise (TypeError("int64", repr(results['total_space'])))
-        if type(results['datasources']) <> type([]):
+        if not isinstance(results['datasources'], list):
             raise (TypeError("string list", repr(results['datasources'])))
         for tmp_17 in results['datasources']:
-            if type(tmp_17) <> type("") and type(tmp_17) <> type(u""):
+            if not isinstance(tmp_17, str) and not isinstance(tmp_17, unicode):
                 raise (TypeError("string", repr(tmp_17)))
-        if type(results['clustered']) <> type(True):
+        if not isinstance(results['clustered'], bool):
             raise (TypeError("bool", repr(results['clustered'])))
         if results['health'][0] == 'Healthy':
-            if type(results['health'][1]) <> type("") and type(results['health'][1]) <> type(u""):
+            if not isinstance(results['health'][1], str) and not isinstance(results['health'][1], unicode):
                 raise (TypeError("string", repr(results['health'][1])))
         elif results['health'][0] == 'Recovering':
-            if type(results['health'][1]) <> type("") and type(results['health'][1]) <> type(u""):
+            if not isinstance(results['health'][1], str) and not isinstance(results['health'][1], unicode):
                 raise (TypeError("string", repr(results['health'][1])))
         return results
     def set_name(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('new_name')):
+        if not('new_name' in args):
             raise UnmarshalException('argument missing', 'new_name', '')
         new_name = args["new_name"]
-        if type(new_name) <> type("") and type(new_name) <> type(u""):
+        if not isinstance(new_name, str) and not isinstance(new_name, unicode):
             raise (TypeError("string", repr(new_name)))
         results = self._impl.set_name(dbg, sr, new_name)
         return results
     def set_description(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
-        if not(args.has_key('new_description')):
+        if not('new_description' in args):
             raise UnmarshalException('argument missing', 'new_description', '')
         new_description = args["new_description"]
-        if type(new_description) <> type("") and type(new_description) <> type(u""):
+        if not isinstance(new_description, str) and not isinstance(new_description, unicode):
             raise (TypeError("string", repr(new_description)))
         results = self._impl.set_description(dbg, sr, new_description)
         return results
     def ls(self, args):
         """type-check inputs, call implementation, type-check outputs and return"""
-        if type(args) <> type({}):
+        if not isinstance(args, dict):
             raise (UnmarshalException('arguments', 'dict', repr(args)))
-        if not(args.has_key('dbg')):
+        if not('dbg' in args):
             raise UnmarshalException('argument missing', 'dbg', '')
         dbg = args["dbg"]
-        if type(dbg) <> type("") and type(dbg) <> type(u""):
+        if not isinstance(dbg, str) and not isinstance(dbg, unicode):
             raise (TypeError("string", repr(dbg)))
-        if not(args.has_key('sr')):
+        if not('sr' in args):
             raise UnmarshalException('argument missing', 'sr', '')
         sr = args["sr"]
-        if type(sr) <> type("") and type(sr) <> type(u""):
+        if not isinstance(sr, str) and not isinstance(sr, unicode):
             raise (TypeError("string", repr(sr)))
         results = self._impl.ls(dbg, sr)
-        if type(results) <> type([]):
+        if not isinstance(results, list):
             raise (TypeError("8 list", repr(results)))
         for tmp_18 in results:
-            if type(tmp_18['key']) <> type("") and type(tmp_18['key']) <> type(u""):
+            if not isinstance(tmp_18['key'], str) and not isinstance(tmp_18['key'], unicode):
                 raise (TypeError("string", repr(tmp_18['key'])))
-            if tmp_18['uuid'] <> None:
-                if type(tmp_18['uuid']) <> type("") and type(tmp_18['uuid']) <> type(u""):
+            if tmp_18['uuid'] is not None:
+                if not isinstance(tmp_18['uuid'], str) and not isinstance(tmp_18['uuid'], unicode):
                     raise (TypeError("string", repr(tmp_18['uuid'])))
-            if type(tmp_18['name']) <> type("") and type(tmp_18['name']) <> type(u""):
+            if not isinstance(tmp_18['name'], str) and not isinstance(tmp_18['name'], unicode):
                 raise (TypeError("string", repr(tmp_18['name'])))
-            if type(tmp_18['description']) <> type("") and type(tmp_18['description']) <> type(u""):
+            if not isinstance(tmp_18['description'], str) and not isinstance(tmp_18['description'], unicode):
                 raise (TypeError("string", repr(tmp_18['description'])))
-            if type(tmp_18['read_write']) <> type(True):
+            if not isinstance(tmp_18['read_write'], bool):
                 raise (TypeError("bool", repr(tmp_18['read_write'])))
             if not(is_long(tmp_18['virtual_size'])):
                 raise (TypeError("int64", repr(tmp_18['virtual_size'])))
             if not(is_long(tmp_18['physical_utilisation'])):
                 raise (TypeError("int64", repr(tmp_18['physical_utilisation'])))
-            if type(tmp_18['uri']) <> type([]):
+            if not isinstance(tmp_18['uri'], list):
                 raise (TypeError("string list", repr(tmp_18['uri'])))
             for tmp_19 in tmp_18['uri']:
-                if type(tmp_19) <> type("") and type(tmp_19) <> type(u""):
+                if not isinstance(tmp_19, str) and not isinstance(tmp_19, unicode):
                     raise (TypeError("string", repr(tmp_19)))
-            if type(tmp_18['keys']) <> type({}):
+            if not isinstance(tmp_18['keys'], dict):
                 raise (TypeError("(string * string) list", repr(tmp_18['keys'])))
             for tmp_20 in tmp_18['keys'].keys():
-                if type(tmp_20) <> type("") and type(tmp_20) <> type(u""):
+                if not isinstance(tmp_20, str) and not isinstance(tmp_20, unicode):
                     raise (TypeError("string", repr(tmp_20)))
             for tmp_20 in tmp_18['keys'].values():
-                if type(tmp_20) <> type("") and type(tmp_20) <> type(u""):
+                if not isinstance(tmp_20, str) and not isinstance(tmp_20, unicode):
                     raise (TypeError("string", repr(tmp_20)))
         return results
     def _dispatch(self, method, params):
@@ -1140,8 +1143,6 @@ class SR_test:
         result = {}
         result["volumes"] = [ { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }, { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } } ]
         return result
-import argparse, traceback
-import xapi
 class SR_commandline():
     """Parse command-line arguments and call an implementation."""
     def __init__(self, impl):
@@ -1172,7 +1173,7 @@ class SR_commandline():
         parser.add_argument('uri', action='store', help='The Storage Repository URI')
         parser.add_argument('name', action='store', help='Human-readable name for the SR')
         parser.add_argument('description', action='store', help='Human-readable description for the SR')
-        parser.add_argument('--configuration', default = {}, nargs=2, action=xapi.ListAction, help='Plugin-specific configuration which describes where and how to create the storage repository. This may include the physical block device name, a remote NFS server and path or an RBD storage pool.')
+        parser.add_argument('--configuration', default={}, nargs=2, action=xapi.ListAction, help='Plugin-specific configuration which describes where and how to create the storage repository. This may include the physical block device name, a remote NFS server and path or an RBD storage pool.')
         return vars(parser.parse_args())
     def _parse_attach(self):
         """[attach uri]: attaches the SR to the local host. Once an SR is attached then volumes may be manipulated."""
@@ -1379,25 +1380,25 @@ class SR_commandline():
                 raise e
 class volume_server_dispatcher:
     """Demux calls to individual interface server_dispatchers"""
-    def __init__(self, Volume = None, SR = None):
+    def __init__(self, Volume=None, SR=None):
         self.Volume = Volume
         self.SR = SR
     def _dispatch(self, method, params):
         try:
-            log("method = %s params = %s" % (method, repr(params)))
+            logging.debug("method = %s params = %s" % (method, repr(params)))
             if method.startswith("Volume") and self.Volume:
                 return self.Volume._dispatch(method, params)
             elif method.startswith("SR") and self.SR:
                 return self.SR._dispatch(method, params)
             raise UnknownMethod(method)
         except Exception, e:
-            log("caught %s" % e)
+            logging.info("caught %s" % e)
             traceback.print_exc()
             try:
                 # A declared (expected) failure will have a .failure() method
-                log("returning %s" % (repr(e.failure())))
+                logging.debug("returning %s" % (repr(e.failure())))
                 return e.failure()
-            except:
+            except AttributeError:
                 # An undeclared (unexpected) failure is wrapped as InternalError
                 return (InternalError(str(e)).failure())
 class volume_server_test(volume_server_dispatcher):

--- a/python/xapi/storage/api/volume.py
+++ b/python/xapi/storage/api/volume.py
@@ -1,0 +1,1406 @@
+from xapi import *
+import traceback
+class Sr_not_attached(Rpc_light_failure):
+    def __init__(self, arg_0):
+        Rpc_light_failure.__init__(self, "Sr_not_attached", [ arg_0 ])
+        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+            raise (TypeError("string", repr(arg_0)))
+        self.arg_0 = arg_0
+class SR_does_not_exist(Rpc_light_failure):
+    def __init__(self, arg_0):
+        Rpc_light_failure.__init__(self, "SR_does_not_exist", [ arg_0 ])
+        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+            raise (TypeError("string", repr(arg_0)))
+        self.arg_0 = arg_0
+class Volume_does_not_exist(Rpc_light_failure):
+    def __init__(self, arg_0):
+        Rpc_light_failure.__init__(self, "Volume_does_not_exist", [ arg_0 ])
+        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+            raise (TypeError("string", repr(arg_0)))
+        self.arg_0 = arg_0
+class Unimplemented(Rpc_light_failure):
+    def __init__(self, arg_0):
+        Rpc_light_failure.__init__(self, "Unimplemented", [ arg_0 ])
+        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+            raise (TypeError("string", repr(arg_0)))
+        self.arg_0 = arg_0
+class Cancelled(Rpc_light_failure):
+    def __init__(self, arg_0):
+        Rpc_light_failure.__init__(self, "Cancelled", [ arg_0 ])
+        if type(arg_0) <> type("") and type(arg_0) <> type(u""):
+            raise (TypeError("string", repr(arg_0)))
+        self.arg_0 = arg_0
+class Volume_server_dispatcher:
+    """Operations which operate on volumes (also known as Virtual Disk Images)"""
+    def __init__(self, impl):
+        """impl is a proxy object whose methods contain the implementation"""
+        self._impl = impl
+    def create(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('name')):
+            raise UnmarshalException('argument missing', 'name', '')
+        name = args["name"]
+        if type(name) <> type("") and type(name) <> type(u""):
+            raise (TypeError("string", repr(name)))
+        if not(args.has_key('description')):
+            raise UnmarshalException('argument missing', 'description', '')
+        description = args["description"]
+        if type(description) <> type("") and type(description) <> type(u""):
+            raise (TypeError("string", repr(description)))
+        if not(args.has_key('size')):
+            raise UnmarshalException('argument missing', 'size', '')
+        size = args["size"]
+        if not(is_long(size)):
+            raise (TypeError("int64", repr(size)))
+        results = self._impl.create(dbg, sr, name, description, size)
+        if type(results['key']) <> type("") and type(results['key']) <> type(u""):
+            raise (TypeError("string", repr(results['key'])))
+        if results['uuid'] <> None:
+            if type(results['uuid']) <> type("") and type(results['uuid']) <> type(u""):
+                raise (TypeError("string", repr(results['uuid'])))
+        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+            raise (TypeError("string", repr(results['name'])))
+        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+            raise (TypeError("string", repr(results['description'])))
+        if type(results['read_write']) <> type(True):
+            raise (TypeError("bool", repr(results['read_write'])))
+        if not(is_long(results['virtual_size'])):
+            raise (TypeError("int64", repr(results['virtual_size'])))
+        if not(is_long(results['physical_utilisation'])):
+            raise (TypeError("int64", repr(results['physical_utilisation'])))
+        if type(results['uri']) <> type([]):
+            raise (TypeError("string list", repr(results['uri'])))
+        for tmp_5 in results['uri']:
+            if type(tmp_5) <> type("") and type(tmp_5) <> type(u""):
+                raise (TypeError("string", repr(tmp_5)))
+        if type(results['keys']) <> type({}):
+            raise (TypeError("(string * string) list", repr(results['keys'])))
+        for tmp_6 in results['keys'].keys():
+            if type(tmp_6) <> type("") and type(tmp_6) <> type(u""):
+                raise (TypeError("string", repr(tmp_6)))
+        for tmp_6 in results['keys'].values():
+            if type(tmp_6) <> type("") and type(tmp_6) <> type(u""):
+                raise (TypeError("string", repr(tmp_6)))
+        return results
+    def snapshot(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('key')):
+            raise UnmarshalException('argument missing', 'key', '')
+        key = args["key"]
+        if type(key) <> type("") and type(key) <> type(u""):
+            raise (TypeError("string", repr(key)))
+        results = self._impl.snapshot(dbg, sr, key)
+        if type(results['key']) <> type("") and type(results['key']) <> type(u""):
+            raise (TypeError("string", repr(results['key'])))
+        if results['uuid'] <> None:
+            if type(results['uuid']) <> type("") and type(results['uuid']) <> type(u""):
+                raise (TypeError("string", repr(results['uuid'])))
+        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+            raise (TypeError("string", repr(results['name'])))
+        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+            raise (TypeError("string", repr(results['description'])))
+        if type(results['read_write']) <> type(True):
+            raise (TypeError("bool", repr(results['read_write'])))
+        if not(is_long(results['virtual_size'])):
+            raise (TypeError("int64", repr(results['virtual_size'])))
+        if not(is_long(results['physical_utilisation'])):
+            raise (TypeError("int64", repr(results['physical_utilisation'])))
+        if type(results['uri']) <> type([]):
+            raise (TypeError("string list", repr(results['uri'])))
+        for tmp_7 in results['uri']:
+            if type(tmp_7) <> type("") and type(tmp_7) <> type(u""):
+                raise (TypeError("string", repr(tmp_7)))
+        if type(results['keys']) <> type({}):
+            raise (TypeError("(string * string) list", repr(results['keys'])))
+        for tmp_8 in results['keys'].keys():
+            if type(tmp_8) <> type("") and type(tmp_8) <> type(u""):
+                raise (TypeError("string", repr(tmp_8)))
+        for tmp_8 in results['keys'].values():
+            if type(tmp_8) <> type("") and type(tmp_8) <> type(u""):
+                raise (TypeError("string", repr(tmp_8)))
+        return results
+    def clone(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('key')):
+            raise UnmarshalException('argument missing', 'key', '')
+        key = args["key"]
+        if type(key) <> type("") and type(key) <> type(u""):
+            raise (TypeError("string", repr(key)))
+        results = self._impl.clone(dbg, sr, key)
+        if type(results['key']) <> type("") and type(results['key']) <> type(u""):
+            raise (TypeError("string", repr(results['key'])))
+        if results['uuid'] <> None:
+            if type(results['uuid']) <> type("") and type(results['uuid']) <> type(u""):
+                raise (TypeError("string", repr(results['uuid'])))
+        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+            raise (TypeError("string", repr(results['name'])))
+        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+            raise (TypeError("string", repr(results['description'])))
+        if type(results['read_write']) <> type(True):
+            raise (TypeError("bool", repr(results['read_write'])))
+        if not(is_long(results['virtual_size'])):
+            raise (TypeError("int64", repr(results['virtual_size'])))
+        if not(is_long(results['physical_utilisation'])):
+            raise (TypeError("int64", repr(results['physical_utilisation'])))
+        if type(results['uri']) <> type([]):
+            raise (TypeError("string list", repr(results['uri'])))
+        for tmp_9 in results['uri']:
+            if type(tmp_9) <> type("") and type(tmp_9) <> type(u""):
+                raise (TypeError("string", repr(tmp_9)))
+        if type(results['keys']) <> type({}):
+            raise (TypeError("(string * string) list", repr(results['keys'])))
+        for tmp_10 in results['keys'].keys():
+            if type(tmp_10) <> type("") and type(tmp_10) <> type(u""):
+                raise (TypeError("string", repr(tmp_10)))
+        for tmp_10 in results['keys'].values():
+            if type(tmp_10) <> type("") and type(tmp_10) <> type(u""):
+                raise (TypeError("string", repr(tmp_10)))
+        return results
+    def destroy(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('key')):
+            raise UnmarshalException('argument missing', 'key', '')
+        key = args["key"]
+        if type(key) <> type("") and type(key) <> type(u""):
+            raise (TypeError("string", repr(key)))
+        results = self._impl.destroy(dbg, sr, key)
+        return results
+    def set_name(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('key')):
+            raise UnmarshalException('argument missing', 'key', '')
+        key = args["key"]
+        if type(key) <> type("") and type(key) <> type(u""):
+            raise (TypeError("string", repr(key)))
+        if not(args.has_key('new_name')):
+            raise UnmarshalException('argument missing', 'new_name', '')
+        new_name = args["new_name"]
+        if type(new_name) <> type("") and type(new_name) <> type(u""):
+            raise (TypeError("string", repr(new_name)))
+        results = self._impl.set_name(dbg, sr, key, new_name)
+        return results
+    def set_description(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('key')):
+            raise UnmarshalException('argument missing', 'key', '')
+        key = args["key"]
+        if type(key) <> type("") and type(key) <> type(u""):
+            raise (TypeError("string", repr(key)))
+        if not(args.has_key('new_description')):
+            raise UnmarshalException('argument missing', 'new_description', '')
+        new_description = args["new_description"]
+        if type(new_description) <> type("") and type(new_description) <> type(u""):
+            raise (TypeError("string", repr(new_description)))
+        results = self._impl.set_description(dbg, sr, key, new_description)
+        return results
+    def set(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('key')):
+            raise UnmarshalException('argument missing', 'key', '')
+        key = args["key"]
+        if type(key) <> type("") and type(key) <> type(u""):
+            raise (TypeError("string", repr(key)))
+        if not(args.has_key('k')):
+            raise UnmarshalException('argument missing', 'k', '')
+        k = args["k"]
+        if type(k) <> type("") and type(k) <> type(u""):
+            raise (TypeError("string", repr(k)))
+        if not(args.has_key('v')):
+            raise UnmarshalException('argument missing', 'v', '')
+        v = args["v"]
+        if type(v) <> type("") and type(v) <> type(u""):
+            raise (TypeError("string", repr(v)))
+        results = self._impl.set(dbg, sr, key, k, v)
+        return results
+    def unset(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('key')):
+            raise UnmarshalException('argument missing', 'key', '')
+        key = args["key"]
+        if type(key) <> type("") and type(key) <> type(u""):
+            raise (TypeError("string", repr(key)))
+        if not(args.has_key('k')):
+            raise UnmarshalException('argument missing', 'k', '')
+        k = args["k"]
+        if type(k) <> type("") and type(k) <> type(u""):
+            raise (TypeError("string", repr(k)))
+        results = self._impl.unset(dbg, sr, key, k)
+        return results
+    def resize(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('key')):
+            raise UnmarshalException('argument missing', 'key', '')
+        key = args["key"]
+        if type(key) <> type("") and type(key) <> type(u""):
+            raise (TypeError("string", repr(key)))
+        if not(args.has_key('new_size')):
+            raise UnmarshalException('argument missing', 'new_size', '')
+        new_size = args["new_size"]
+        if not(is_long(new_size)):
+            raise (TypeError("int64", repr(new_size)))
+        results = self._impl.resize(dbg, sr, key, new_size)
+        return results
+    def stat(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('key')):
+            raise UnmarshalException('argument missing', 'key', '')
+        key = args["key"]
+        if type(key) <> type("") and type(key) <> type(u""):
+            raise (TypeError("string", repr(key)))
+        results = self._impl.stat(dbg, sr, key)
+        if type(results['key']) <> type("") and type(results['key']) <> type(u""):
+            raise (TypeError("string", repr(results['key'])))
+        if results['uuid'] <> None:
+            if type(results['uuid']) <> type("") and type(results['uuid']) <> type(u""):
+                raise (TypeError("string", repr(results['uuid'])))
+        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+            raise (TypeError("string", repr(results['name'])))
+        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+            raise (TypeError("string", repr(results['description'])))
+        if type(results['read_write']) <> type(True):
+            raise (TypeError("bool", repr(results['read_write'])))
+        if not(is_long(results['virtual_size'])):
+            raise (TypeError("int64", repr(results['virtual_size'])))
+        if not(is_long(results['physical_utilisation'])):
+            raise (TypeError("int64", repr(results['physical_utilisation'])))
+        if type(results['uri']) <> type([]):
+            raise (TypeError("string list", repr(results['uri'])))
+        for tmp_11 in results['uri']:
+            if type(tmp_11) <> type("") and type(tmp_11) <> type(u""):
+                raise (TypeError("string", repr(tmp_11)))
+        if type(results['keys']) <> type({}):
+            raise (TypeError("(string * string) list", repr(results['keys'])))
+        for tmp_12 in results['keys'].keys():
+            if type(tmp_12) <> type("") and type(tmp_12) <> type(u""):
+                raise (TypeError("string", repr(tmp_12)))
+        for tmp_12 in results['keys'].values():
+            if type(tmp_12) <> type("") and type(tmp_12) <> type(u""):
+                raise (TypeError("string", repr(tmp_12)))
+        return results
+    def _dispatch(self, method, params):
+        """type check inputs, call implementation, type check outputs and return"""
+        args = params[0]
+        if method == "Volume.create":
+            return success(self.create(args))
+        elif method == "Volume.snapshot":
+            return success(self.snapshot(args))
+        elif method == "Volume.clone":
+            return success(self.clone(args))
+        elif method == "Volume.destroy":
+            return success(self.destroy(args))
+        elif method == "Volume.set_name":
+            return success(self.set_name(args))
+        elif method == "Volume.set_description":
+            return success(self.set_description(args))
+        elif method == "Volume.set":
+            return success(self.set(args))
+        elif method == "Volume.unset":
+            return success(self.unset(args))
+        elif method == "Volume.resize":
+            return success(self.resize(args))
+        elif method == "Volume.stat":
+            return success(self.stat(args))
+class Volume_skeleton:
+    """Operations which operate on volumes (also known as Virtual Disk Images)"""
+    def __init__(self):
+        pass
+    def create(self, dbg, sr, name, description, size):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.create")
+    def snapshot(self, dbg, sr, key):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.snapshot")
+    def clone(self, dbg, sr, key):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.clone")
+    def destroy(self, dbg, sr, key):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.destroy")
+    def set_name(self, dbg, sr, key, new_name):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.set_name")
+    def set_description(self, dbg, sr, key, new_description):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.set_description")
+    def set(self, dbg, sr, key, k, v):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.set")
+    def unset(self, dbg, sr, key, k):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.unset")
+    def resize(self, dbg, sr, key, new_size):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.resize")
+    def stat(self, dbg, sr, key):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        raise Unimplemented("Volume.stat")
+class Volume_test:
+    """Operations which operate on volumes (also known as Virtual Disk Images)"""
+    def __init__(self):
+        pass
+    def create(self, dbg, sr, name, description, size):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }
+        return result
+    def snapshot(self, dbg, sr, key):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }
+        return result
+    def clone(self, dbg, sr, key):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }
+        return result
+    def destroy(self, dbg, sr, key):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        return result
+    def set_name(self, dbg, sr, key, new_name):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        return result
+    def set_description(self, dbg, sr, key, new_description):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        return result
+    def set(self, dbg, sr, key, k, v):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        return result
+    def unset(self, dbg, sr, key, k):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        return result
+    def resize(self, dbg, sr, key, new_size):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        return result
+    def stat(self, dbg, sr, key):
+        """Operations which operate on volumes (also known as Virtual Disk Images)"""
+        result = {}
+        result["volume"] = { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }
+        return result
+import argparse, traceback
+import xapi
+class Volume_commandline():
+    """Parse command-line arguments and call an implementation."""
+    def __init__(self, impl):
+        self.impl = impl
+        self.dispatcher = Volume_server_dispatcher(self.impl)
+    def _parse_create(self):
+        """[create sr name description size] creates a new volume in [sr] with [name] and [description]. The volume will have size >= [size] i.e. it is always permissable for an implementation to round-up the volume to the nearest convenient block size"""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[create sr name description size] creates a new volume in [sr] with [name] and [description]. The volume will have size >= [size] i.e. it is always permissable for an implementation to round-up the volume to the nearest convenient block size')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('name', action='store', help='A human-readable name to associate with the new disk. This name is intended to be short, to be a good summary of the disk.')
+        parser.add_argument('description', action='store', help='A human-readable description to associate with the new disk. This can be arbitrarily long, up to the general string size limit.')
+        parser.add_argument('size', action='store', help='A minimum size (in bytes) for the disk. Depending on the characteristics of the implementation this may be rounded up to (for example) the nearest convenient block size. The created disk will not be smaller than this size.')
+        return vars(parser.parse_args())
+    def _parse_snapshot(self):
+        """[snapshot sr volume] creates a new volue which is a  snapshot of [volume] in [sr]. Snapshots should never be written to; they are intended for backup/restore only. Note the name and description are copied but any extra metadata associated by [set] is not copied."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[snapshot sr volume] creates a new volue which is a  snapshot of [volume] in [sr]. Snapshots should never be written to; they are intended for backup/restore only. Note the name and description are copied but any extra metadata associated by [set] is not copied.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('key', action='store', help='The volume key')
+        return vars(parser.parse_args())
+    def _parse_clone(self):
+        """[clone sr volume] creates a new volume which is a writable clone of [volume] in [sr]. Note the name and description are copied but any extra metadata associated by [set] is not copied."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[clone sr volume] creates a new volume which is a writable clone of [volume] in [sr]. Note the name and description are copied but any extra metadata associated by [set] is not copied.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('key', action='store', help='The volume key')
+        return vars(parser.parse_args())
+    def _parse_destroy(self):
+        """[destroy sr volume] removes [volume] from [sr]"""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[destroy sr volume] removes [volume] from [sr]')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('key', action='store', help='The volume key')
+        return vars(parser.parse_args())
+    def _parse_set_name(self):
+        """[set_name sr volume new_name] changes the name of [volume]"""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[set_name sr volume new_name] changes the name of [volume]')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('key', action='store', help='The volume key')
+        parser.add_argument('new_name', action='store', help='New name')
+        return vars(parser.parse_args())
+    def _parse_set_description(self):
+        """[set_description sr volume new_description] changes the description of [volume]"""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[set_description sr volume new_description] changes the description of [volume]')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('key', action='store', help='The volume key')
+        parser.add_argument('new_description', action='store', help='New description')
+        return vars(parser.parse_args())
+    def _parse_set(self):
+        """[set sr volume key value] associates [key] with [value] in the metadata of [volume] Note these keys and values are not interpreted by the plugin; they are intended for the higher-level software only."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[set sr volume key value] associates [key] with [value] in the metadata of [volume] Note these keys and values are not interpreted by the plugin; they are intended for the higher-level software only.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('key', action='store', help='The volume key')
+        parser.add_argument('k', action='store', help='Key')
+        parser.add_argument('v', action='store', help='Value')
+        return vars(parser.parse_args())
+    def _parse_unset(self):
+        """[unset sr volume key] removes [key] and any value associated with it from the metadata of [volume] Note these keys and values are not interpreted by the plugin; they are intended for the higher-level software only."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[unset sr volume key] removes [key] and any value associated with it from the metadata of [volume] Note these keys and values are not interpreted by the plugin; they are intended for the higher-level software only.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('key', action='store', help='The volume key')
+        parser.add_argument('k', action='store', help='Key')
+        return vars(parser.parse_args())
+    def _parse_resize(self):
+        """[resize sr volume new_size] enlarges [volume] to be at least [new_size]."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[resize sr volume new_size] enlarges [volume] to be at least [new_size].')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('key', action='store', help='The volume key')
+        parser.add_argument('new_size', action='store', help='New disk size')
+        return vars(parser.parse_args())
+    def _parse_stat(self):
+        """[stat sr volume] returns metadata associated with [volume]."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[stat sr volume] returns metadata associated with [volume].')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('key', action='store', help='The volume key')
+        return vars(parser.parse_args())
+    def create(self):
+        use_json = False
+        try:
+            request = self._parse_create()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.create(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def snapshot(self):
+        use_json = False
+        try:
+            request = self._parse_snapshot()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.snapshot(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def clone(self):
+        use_json = False
+        try:
+            request = self._parse_clone()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.clone(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def destroy(self):
+        use_json = False
+        try:
+            request = self._parse_destroy()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.destroy(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def set_name(self):
+        use_json = False
+        try:
+            request = self._parse_set_name()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.set_name(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def set_description(self):
+        use_json = False
+        try:
+            request = self._parse_set_description()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.set_description(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def set(self):
+        use_json = False
+        try:
+            request = self._parse_set()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.set(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def unset(self):
+        use_json = False
+        try:
+            request = self._parse_unset()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.unset(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def resize(self):
+        use_json = False
+        try:
+            request = self._parse_resize()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.resize(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def stat(self):
+        use_json = False
+        try:
+            request = self._parse_stat()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.stat(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+class SR_server_dispatcher:
+    """Operations which act on Storage Repositories"""
+    def __init__(self, impl):
+        """impl is a proxy object whose methods contain the implementation"""
+        self._impl = impl
+    def probe(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('uri')):
+            raise UnmarshalException('argument missing', 'uri', '')
+        uri = args["uri"]
+        if type(uri) <> type("") and type(uri) <> type(u""):
+            raise (TypeError("string", repr(uri)))
+        results = self._impl.probe(dbg, uri)
+        if type(results['srs']) <> type([]):
+            raise (TypeError("7 list", repr(results['srs'])))
+        for tmp_13 in results['srs']:
+            if type(tmp_13['sr']) <> type("") and type(tmp_13['sr']) <> type(u""):
+                raise (TypeError("string", repr(tmp_13['sr'])))
+            if type(tmp_13['name']) <> type("") and type(tmp_13['name']) <> type(u""):
+                raise (TypeError("string", repr(tmp_13['name'])))
+            if type(tmp_13['description']) <> type("") and type(tmp_13['description']) <> type(u""):
+                raise (TypeError("string", repr(tmp_13['description'])))
+            if not(is_long(tmp_13['free_space'])):
+                raise (TypeError("int64", repr(tmp_13['free_space'])))
+            if not(is_long(tmp_13['total_space'])):
+                raise (TypeError("int64", repr(tmp_13['total_space'])))
+            if type(tmp_13['datasources']) <> type([]):
+                raise (TypeError("string list", repr(tmp_13['datasources'])))
+            for tmp_14 in tmp_13['datasources']:
+                if type(tmp_14) <> type("") and type(tmp_14) <> type(u""):
+                    raise (TypeError("string", repr(tmp_14)))
+            if type(tmp_13['clustered']) <> type(True):
+                raise (TypeError("bool", repr(tmp_13['clustered'])))
+            if tmp_13['health'][0] == 'Healthy':
+                if type(tmp_13['health'][1]) <> type("") and type(tmp_13['health'][1]) <> type(u""):
+                    raise (TypeError("string", repr(tmp_13['health'][1])))
+            elif tmp_13['health'][0] == 'Recovering':
+                if type(tmp_13['health'][1]) <> type("") and type(tmp_13['health'][1]) <> type(u""):
+                    raise (TypeError("string", repr(tmp_13['health'][1])))
+        if type(results['uris']) <> type([]):
+            raise (TypeError("string list", repr(results['uris'])))
+        for tmp_15 in results['uris']:
+            if type(tmp_15) <> type("") and type(tmp_15) <> type(u""):
+                raise (TypeError("string", repr(tmp_15)))
+        return results
+    def create(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('uri')):
+            raise UnmarshalException('argument missing', 'uri', '')
+        uri = args["uri"]
+        if type(uri) <> type("") and type(uri) <> type(u""):
+            raise (TypeError("string", repr(uri)))
+        if not(args.has_key('name')):
+            raise UnmarshalException('argument missing', 'name', '')
+        name = args["name"]
+        if type(name) <> type("") and type(name) <> type(u""):
+            raise (TypeError("string", repr(name)))
+        if not(args.has_key('description')):
+            raise UnmarshalException('argument missing', 'description', '')
+        description = args["description"]
+        if type(description) <> type("") and type(description) <> type(u""):
+            raise (TypeError("string", repr(description)))
+        if not(args.has_key('configuration')):
+            raise UnmarshalException('argument missing', 'configuration', '')
+        configuration = args["configuration"]
+        if type(configuration) <> type({}):
+            raise (TypeError("(string * string) list", repr(configuration)))
+        for tmp_16 in configuration.keys():
+            if type(tmp_16) <> type("") and type(tmp_16) <> type(u""):
+                raise (TypeError("string", repr(tmp_16)))
+        for tmp_16 in configuration.values():
+            if type(tmp_16) <> type("") and type(tmp_16) <> type(u""):
+                raise (TypeError("string", repr(tmp_16)))
+        results = self._impl.create(dbg, uri, name, description, configuration)
+        return results
+    def attach(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('uri')):
+            raise UnmarshalException('argument missing', 'uri', '')
+        uri = args["uri"]
+        if type(uri) <> type("") and type(uri) <> type(u""):
+            raise (TypeError("string", repr(uri)))
+        results = self._impl.attach(dbg, uri)
+        if type(results) <> type("") and type(results) <> type(u""):
+            raise (TypeError("string", repr(results)))
+        return results
+    def detach(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        results = self._impl.detach(dbg, sr)
+        return results
+    def destroy(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        results = self._impl.destroy(dbg, sr)
+        return results
+    def stat(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        results = self._impl.stat(dbg, sr)
+        if type(results['sr']) <> type("") and type(results['sr']) <> type(u""):
+            raise (TypeError("string", repr(results['sr'])))
+        if type(results['name']) <> type("") and type(results['name']) <> type(u""):
+            raise (TypeError("string", repr(results['name'])))
+        if type(results['description']) <> type("") and type(results['description']) <> type(u""):
+            raise (TypeError("string", repr(results['description'])))
+        if not(is_long(results['free_space'])):
+            raise (TypeError("int64", repr(results['free_space'])))
+        if not(is_long(results['total_space'])):
+            raise (TypeError("int64", repr(results['total_space'])))
+        if type(results['datasources']) <> type([]):
+            raise (TypeError("string list", repr(results['datasources'])))
+        for tmp_17 in results['datasources']:
+            if type(tmp_17) <> type("") and type(tmp_17) <> type(u""):
+                raise (TypeError("string", repr(tmp_17)))
+        if type(results['clustered']) <> type(True):
+            raise (TypeError("bool", repr(results['clustered'])))
+        if results['health'][0] == 'Healthy':
+            if type(results['health'][1]) <> type("") and type(results['health'][1]) <> type(u""):
+                raise (TypeError("string", repr(results['health'][1])))
+        elif results['health'][0] == 'Recovering':
+            if type(results['health'][1]) <> type("") and type(results['health'][1]) <> type(u""):
+                raise (TypeError("string", repr(results['health'][1])))
+        return results
+    def set_name(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('new_name')):
+            raise UnmarshalException('argument missing', 'new_name', '')
+        new_name = args["new_name"]
+        if type(new_name) <> type("") and type(new_name) <> type(u""):
+            raise (TypeError("string", repr(new_name)))
+        results = self._impl.set_name(dbg, sr, new_name)
+        return results
+    def set_description(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        if not(args.has_key('new_description')):
+            raise UnmarshalException('argument missing', 'new_description', '')
+        new_description = args["new_description"]
+        if type(new_description) <> type("") and type(new_description) <> type(u""):
+            raise (TypeError("string", repr(new_description)))
+        results = self._impl.set_description(dbg, sr, new_description)
+        return results
+    def ls(self, args):
+        """type-check inputs, call implementation, type-check outputs and return"""
+        if type(args) <> type({}):
+            raise (UnmarshalException('arguments', 'dict', repr(args)))
+        if not(args.has_key('dbg')):
+            raise UnmarshalException('argument missing', 'dbg', '')
+        dbg = args["dbg"]
+        if type(dbg) <> type("") and type(dbg) <> type(u""):
+            raise (TypeError("string", repr(dbg)))
+        if not(args.has_key('sr')):
+            raise UnmarshalException('argument missing', 'sr', '')
+        sr = args["sr"]
+        if type(sr) <> type("") and type(sr) <> type(u""):
+            raise (TypeError("string", repr(sr)))
+        results = self._impl.ls(dbg, sr)
+        if type(results) <> type([]):
+            raise (TypeError("8 list", repr(results)))
+        for tmp_18 in results:
+            if type(tmp_18['key']) <> type("") and type(tmp_18['key']) <> type(u""):
+                raise (TypeError("string", repr(tmp_18['key'])))
+            if tmp_18['uuid'] <> None:
+                if type(tmp_18['uuid']) <> type("") and type(tmp_18['uuid']) <> type(u""):
+                    raise (TypeError("string", repr(tmp_18['uuid'])))
+            if type(tmp_18['name']) <> type("") and type(tmp_18['name']) <> type(u""):
+                raise (TypeError("string", repr(tmp_18['name'])))
+            if type(tmp_18['description']) <> type("") and type(tmp_18['description']) <> type(u""):
+                raise (TypeError("string", repr(tmp_18['description'])))
+            if type(tmp_18['read_write']) <> type(True):
+                raise (TypeError("bool", repr(tmp_18['read_write'])))
+            if not(is_long(tmp_18['virtual_size'])):
+                raise (TypeError("int64", repr(tmp_18['virtual_size'])))
+            if not(is_long(tmp_18['physical_utilisation'])):
+                raise (TypeError("int64", repr(tmp_18['physical_utilisation'])))
+            if type(tmp_18['uri']) <> type([]):
+                raise (TypeError("string list", repr(tmp_18['uri'])))
+            for tmp_19 in tmp_18['uri']:
+                if type(tmp_19) <> type("") and type(tmp_19) <> type(u""):
+                    raise (TypeError("string", repr(tmp_19)))
+            if type(tmp_18['keys']) <> type({}):
+                raise (TypeError("(string * string) list", repr(tmp_18['keys'])))
+            for tmp_20 in tmp_18['keys'].keys():
+                if type(tmp_20) <> type("") and type(tmp_20) <> type(u""):
+                    raise (TypeError("string", repr(tmp_20)))
+            for tmp_20 in tmp_18['keys'].values():
+                if type(tmp_20) <> type("") and type(tmp_20) <> type(u""):
+                    raise (TypeError("string", repr(tmp_20)))
+        return results
+    def _dispatch(self, method, params):
+        """type check inputs, call implementation, type check outputs and return"""
+        args = params[0]
+        if method == "SR.probe":
+            return success(self.probe(args))
+        elif method == "SR.create":
+            return success(self.create(args))
+        elif method == "SR.attach":
+            return success(self.attach(args))
+        elif method == "SR.detach":
+            return success(self.detach(args))
+        elif method == "SR.destroy":
+            return success(self.destroy(args))
+        elif method == "SR.stat":
+            return success(self.stat(args))
+        elif method == "SR.set_name":
+            return success(self.set_name(args))
+        elif method == "SR.set_description":
+            return success(self.set_description(args))
+        elif method == "SR.ls":
+            return success(self.ls(args))
+class SR_skeleton:
+    """Operations which act on Storage Repositories"""
+    def __init__(self):
+        pass
+    def probe(self, dbg, uri):
+        """Operations which act on Storage Repositories"""
+        raise Unimplemented("SR.probe")
+    def create(self, dbg, uri, name, description, configuration):
+        """Operations which act on Storage Repositories"""
+        raise Unimplemented("SR.create")
+    def attach(self, dbg, uri):
+        """Operations which act on Storage Repositories"""
+        raise Unimplemented("SR.attach")
+    def detach(self, dbg, sr):
+        """Operations which act on Storage Repositories"""
+        raise Unimplemented("SR.detach")
+    def destroy(self, dbg, sr):
+        """Operations which act on Storage Repositories"""
+        raise Unimplemented("SR.destroy")
+    def stat(self, dbg, sr):
+        """Operations which act on Storage Repositories"""
+        raise Unimplemented("SR.stat")
+    def set_name(self, dbg, sr, new_name):
+        """Operations which act on Storage Repositories"""
+        raise Unimplemented("SR.set_name")
+    def set_description(self, dbg, sr, new_description):
+        """Operations which act on Storage Repositories"""
+        raise Unimplemented("SR.set_description")
+    def ls(self, dbg, sr):
+        """Operations which act on Storage Repositories"""
+        raise Unimplemented("SR.ls")
+class SR_test:
+    """Operations which act on Storage Repositories"""
+    def __init__(self):
+        pass
+    def probe(self, dbg, uri):
+        """Operations which act on Storage Repositories"""
+        result = {}
+        result["result"] = { "srs": [ { "sr": "string", "name": "string", "description": "string", "free_space": 0L, "total_space": 0L, "datasources": [ "string", "string" ], "clustered": True, "health": None }, { "sr": "string", "name": "string", "description": "string", "free_space": 0L, "total_space": 0L, "datasources": [ "string", "string" ], "clustered": True, "health": None } ], "uris": [ "string", "string" ] }
+        return result
+    def create(self, dbg, uri, name, description, configuration):
+        """Operations which act on Storage Repositories"""
+        result = {}
+        return result
+    def attach(self, dbg, uri):
+        """Operations which act on Storage Repositories"""
+        result = {}
+        result["sr"] = "string"
+        return result
+    def detach(self, dbg, sr):
+        """Operations which act on Storage Repositories"""
+        result = {}
+        return result
+    def destroy(self, dbg, sr):
+        """Operations which act on Storage Repositories"""
+        result = {}
+        return result
+    def stat(self, dbg, sr):
+        """Operations which act on Storage Repositories"""
+        result = {}
+        result["sr"] = { "sr": "string", "name": "string", "description": "string", "free_space": 0L, "total_space": 0L, "datasources": [ "string", "string" ], "clustered": True, "health": None }
+        return result
+    def set_name(self, dbg, sr, new_name):
+        """Operations which act on Storage Repositories"""
+        result = {}
+        return result
+    def set_description(self, dbg, sr, new_description):
+        """Operations which act on Storage Repositories"""
+        result = {}
+        return result
+    def ls(self, dbg, sr):
+        """Operations which act on Storage Repositories"""
+        result = {}
+        result["volumes"] = [ { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } }, { "key": "string", "uuid": None, "name": "string", "description": "string", "read_write": True, "virtual_size": 0L, "physical_utilisation": 0L, "uri": [ "string", "string" ], "keys": { "string": "string" } } ]
+        return result
+import argparse, traceback
+import xapi
+class SR_commandline():
+    """Parse command-line arguments and call an implementation."""
+    def __init__(self, impl):
+        self.impl = impl
+        self.dispatcher = SR_server_dispatcher(self.impl)
+    def _parse_probe(self):
+        """[probe uri]: looks for existing SRs on the storage device"""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[probe uri]: looks for existing SRs on the storage device')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('uri', action='store', help='The Storage Repository URI')
+        return vars(parser.parse_args())
+    def _parse_create(self):
+        """[create uri name description configuration]: creates a fresh SR"""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[create uri name description configuration]: creates a fresh SR')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('uri', action='store', help='The Storage Repository URI')
+        parser.add_argument('name', action='store', help='Human-readable name for the SR')
+        parser.add_argument('description', action='store', help='Human-readable description for the SR')
+        parser.add_argument('--configuration', default = {}, nargs=2, action=xapi.ListAction, help='Plugin-specific configuration which describes where and how to create the storage repository. This may include the physical block device name, a remote NFS server and path or an RBD storage pool.')
+        return vars(parser.parse_args())
+    def _parse_attach(self):
+        """[attach uri]: attaches the SR to the local host. Once an SR is attached then volumes may be manipulated."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[attach uri]: attaches the SR to the local host. Once an SR is attached then volumes may be manipulated.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('uri', action='store', help='The Storage Repository URI')
+        return vars(parser.parse_args())
+    def _parse_detach(self):
+        """[detach sr]: detaches the SR, clearing up any associated resources. Once the SR is detached then volumes may not be manipulated."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[detach sr]: detaches the SR, clearing up any associated resources. Once the SR is detached then volumes may not be manipulated.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        return vars(parser.parse_args())
+    def _parse_destroy(self):
+        """[destroy sr]: destroys the [sr] and deletes any volumes associated with it. Note that an SR must be attached to be destroyed; otherwise Sr_not_attached is thrown."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[destroy sr]: destroys the [sr] and deletes any volumes associated with it. Note that an SR must be attached to be destroyed; otherwise Sr_not_attached is thrown.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        return vars(parser.parse_args())
+    def _parse_stat(self):
+        """[stat sr] returns summary metadata associated with [sr]. Note this call does not return details of sub-volumes, see SR.ls."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[stat sr] returns summary metadata associated with [sr]. Note this call does not return details of sub-volumes, see SR.ls.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        return vars(parser.parse_args())
+    def _parse_set_name(self):
+        """[set_name sr new_name] changes the name of [sr]"""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[set_name sr new_name] changes the name of [sr]')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('new_name', action='store', help='The new name of the SR')
+        return vars(parser.parse_args())
+    def _parse_set_description(self):
+        """[set_description sr new_description] changes the description of [sr]"""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[set_description sr new_description] changes the description of [sr]')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        parser.add_argument('new_description', action='store', help='The new description for the SR')
+        return vars(parser.parse_args())
+    def _parse_ls(self):
+        """[ls sr] returns a list of volumes contained within an attached SR."""
+        # in --json mode we don't have any other arguments
+        if ('--json' in sys.argv or '-j' in sys.argv):
+            jsondict = json.loads(sys.stdin.readline(),)
+            jsondict['json'] = True
+            return jsondict
+        parser = argparse.ArgumentParser(description='[ls sr] returns a list of volumes contained within an attached SR.')
+        parser.add_argument('-j', '--json', action='store_const', const=True, default=False, help='Read json from stdin, print json to stdout', required=False)
+        parser.add_argument('dbg', action='store', help='Debug context from the caller')
+        parser.add_argument('sr', action='store', help='The Storage Repository')
+        return vars(parser.parse_args())
+    def probe(self):
+        use_json = False
+        try:
+            request = self._parse_probe()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.probe(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def create(self):
+        use_json = False
+        try:
+            request = self._parse_create()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.create(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def attach(self):
+        use_json = False
+        try:
+            request = self._parse_attach()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.attach(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def detach(self):
+        use_json = False
+        try:
+            request = self._parse_detach()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.detach(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def destroy(self):
+        use_json = False
+        try:
+            request = self._parse_destroy()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.destroy(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def stat(self):
+        use_json = False
+        try:
+            request = self._parse_stat()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.stat(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def set_name(self):
+        use_json = False
+        try:
+            request = self._parse_set_name()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.set_name(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def set_description(self):
+        use_json = False
+        try:
+            request = self._parse_set_description()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.set_description(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+    def ls(self):
+        use_json = False
+        try:
+            request = self._parse_ls()
+            use_json = 'json' in request and request['json']
+            results = self.dispatcher.ls(request)
+            print json.dumps(results)
+        except Exception, e:
+            if use_json:
+                xapi.handle_exception(e)
+            else:
+                traceback.print_exc()
+                raise e
+class volume_server_dispatcher:
+    """Demux calls to individual interface server_dispatchers"""
+    def __init__(self, Volume = None, SR = None):
+        self.Volume = Volume
+        self.SR = SR
+    def _dispatch(self, method, params):
+        try:
+            log("method = %s params = %s" % (method, repr(params)))
+            if method.startswith("Volume") and self.Volume:
+                return self.Volume._dispatch(method, params)
+            elif method.startswith("SR") and self.SR:
+                return self.SR._dispatch(method, params)
+            raise UnknownMethod(method)
+        except Exception, e:
+            log("caught %s" % e)
+            traceback.print_exc()
+            try:
+                # A declared (expected) failure will have a .failure() method
+                log("returning %s" % (repr(e.failure())))
+                return e.failure()
+            except:
+                # An undeclared (unexpected) failure is wrapped as InternalError
+                return (InternalError(str(e)).failure())
+class volume_server_test(volume_server_dispatcher):
+    """Create a server which will respond to all calls, returning arbitrary values. This is intended as a marshal/unmarshal test."""
+    def __init__(self):
+        volume_server_dispatcher.__init__(self, Volume_server_dispatcher(Volume_test()), SR_server_dispatcher(SR_test()))


### PR DESCRIPTION
The already shipped supp-pack with the tmpfs SR imports a python library from
the installed host.
If we update the host without updating the supp-pack we need to keep the python
library backward compatible.

The short-term fix is to keep the old library as was, and put the new library
into a different module.
In the future the code generator can be updated to generate a single python
module that is  compatible with all the APIs.

Need to be merged together with:
https://github.com/xapi-project/xapi-storage-script/pull/57
(and the internal PR on the spec files)