### PR TITLE
Fix tests on xapi-storage master

### DIFF
--- a/ocaml/lib_test/storage_test.ml
+++ b/ocaml/lib_test/storage_test.ml
@@ -88,4 +88,4 @@ let _ =
                 "volume_destroy_request" >:: volume_destroy_request;
                 "volume_snapshot_request" >:: volume_snapshot_request;
               ] in
-  run_test_tt ~verbose:!verbose suite
+  ounit2_of_ounit1 suite |> OUnit2.run_test_tt_main

--- a/rpc-light/volume.create/request
+++ b/rpc-light/volume.create/request
@@ -5,6 +5,7 @@
 	     <member><name>name</name><value>The name_label</value></member>
 	     <member><name>description</name><value>The description</value></member>
              <member><name>size</name><value>0</value></member>
+             <member><name>sharable</name><value><boolean>false</boolean></value></member>
      </struct>
    </value></param></params>
 </methodCall>

--- a/rpc-light/volume.create/response
+++ b/rpc-light/volume.create/response
@@ -12,6 +12,7 @@
                                         <member><name>snapshot_time</name><value>19700101T00:00:00Z</value></member>
                                         <member><name>snapshot_of</name><value></value></member>
                                         <member><name>read_only</name><value><boolean>0</boolean></value></member>
+                                        <member><name>sharable</name><value><boolean>0</boolean></value></member>
 										<member><name>virtual_size</name><value>0</value></member>
 										<member><name>physical_utilisation</name><value>0</value></member>
                                  </struct>


### PR DESCRIPTION
We haven't noticed that the tests were failing on master, because the tests were exiting with code 0 after a failure. Fix that and the actual test failure.