### PR TITLE
generator/html: fix ocaml code example syntax highlight

### DIFF
--- a/generator/html/www.ml
+++ b/generator/html/www.ml
@@ -175,12 +175,12 @@ let tabs_of env is i m =
         );
         div ~cls:"tabs-panel" ~id:id_ocaml (list [
             h4 (string "Client");
-            string (
+            of_string (
               Ocaml.caml2html (
                 Ocaml.example_stub env is i m |> Ocaml.string_of_ts)
             );
             h4 (string "Server");
-            string (
+            of_string (
               Ocaml.caml2html (
                 Ocaml.example_skeleton_user env is i m |> Ocaml.string_of_ts)
             )


### PR DESCRIPTION
Caml2html outputs a string containing html tags, which were escaped by
Cow, and therefore the HTML source of the syntax-highlighted OCaml code
was displayed as plain text.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>