### PR TITLE
review probe API changes to feature/REQ477/master

### DIFF
--- a/generator/lib/control.ml
+++ b/generator/lib/control.ml
@@ -61,7 +61,7 @@ let api =
         ( configuration.name, configuration.ty, configuration.description ),
         [ "complete", Basic Boolean, String.concat " " [
             "True if this configuration is complete and can be used to";
-            "call SR.create. False if it requires further iterative calls";
+            "call SR.create or SR.attach. False if it requires further iterative calls";
             "to SR.probe, to potentially narrow down on a configuration";
             "that can be used.";
           ];

--- a/generator/lib/control.ml
+++ b/generator/lib/control.ml
@@ -65,7 +65,7 @@ let api =
             "to SR.probe, to potentially narrow down on a configuration";
             "that can be used.";
           ];
-          "sr", Name "sr_stat", String.concat " " [
+          "sr", Option (Name "sr_stat"), String.concat " " [
             "Existing SR found for this configuration";
           ]; 
           "extra_info", Dict(String, Basic String), String.concat " " [

--- a/generator/lib/control.ml
+++ b/generator/lib/control.ml
@@ -111,10 +111,15 @@ let api =
     ty = Type.(Basic String);
     description = "The volume key";
   } in
-  let uri = {
-    Arg.name = "uri";
-    ty = Type.(Basic String);
-    description = "The Storage Repository URI";
+  let configuration = {
+    Arg.name = "configuration";
+    ty = Type.(Dict(String, Basic String));
+    description = String.concat " " [
+                    "Plugin-specific configuration which describes where and";
+                    "how to create the storage repository. This may include";
+                    "the physical block device name, a remote NFS server and";
+                    "path or an RBD storage pool.";
+                  ];
   } in
   let uuid = {
     Arg.name = "uuid";
@@ -419,9 +424,9 @@ let api =
           methods = [
             {
               Method.name = "probe";
-              description = "[probe uri]: looks for existing SRs on the storage device";
+              description = "[probe configuration]: looks for existing SRs on the storage device";
               inputs = [
-                uri;
+                configuration;
               ];
               outputs = [
                { Arg.name = "result";
@@ -436,10 +441,10 @@ let api =
             };
             {
               Method.name = "create";
-              description = "[create uuid uri name description configuration]: creates a fresh SR";
+              description = "[create uuid configuration name description]: creates a fresh SR";
               inputs = [
                 uuid;
-                uri;
+                configuration;
                 { Arg.name = "name";
                   ty = Type.(Basic String);
                   description = "Human-readable name for the SR";
@@ -447,28 +452,18 @@ let api =
                   Arg.name = "description";
                   ty = Type.(Basic String);
                   description = "Human-readable description for the SR";
-                }; {
-                  Arg.name = "configuration";
-                  ty = Type.(Dict(String, Basic String));
-                  description = String.concat " " [
-                    "Plugin-specific configuration which describes where and";
-                    "how to create the storage repository. This may include";
-                    "the physical block device name, a remote NFS server and";
-                    "path or an RBD storage pool.";
-                  ];
                 };
               ];
-              outputs = [uri]
+              outputs = [configuration]
             };
             {
               Method.name = "attach";
               description = String.concat " "[
-                "[attach uuid uri]: attaches the SR to the local host. Once an SR";
+                "[attach configuration]: attaches the SR to the local host. Once an SR";
                 "is attached then volumes may be manipulated.";
               ];
               inputs = [
-                uuid;
-                uri;
+                configuration;
               ];
               outputs = [
                 sr;

--- a/generator/lib/python.ml
+++ b/generator/lib/python.ml
@@ -46,7 +46,14 @@ let rec typecheck env ty v =
   | Struct (hd, tl) ->
     let member (name, ty, descr) =
       typecheck env ty (sprintf "%s['%s']" v name) in
-    List.concat (List.map member (hd :: tl))
+    let member_maybe_opt (name, ty, descr) =
+      match ty with
+      | Option _ -> [
+        Line (sprintf "if '%s' in %s:" name v);
+        Block (member (name, ty, descr))
+      ]
+      | _ -> member (name, ty, descr) in
+    List.concat (List.map member_maybe_opt (hd :: tl))
   | Variant (hd, tl) ->
     let member first (name, ty, descr) =
       [ Line (sprintf "%sif %s[0] == '%s':" (if first then "" else "el") v name);

--- a/generator/lib/python.ml
+++ b/generator/lib/python.ml
@@ -206,7 +206,7 @@ let rec skeleton_of_interface unimplemented suffix env i =
   let open Printf in
 
   [
-    Line (sprintf "class %s_%s:" i.Interface.name suffix);
+    Line (sprintf "class %s_%s(object):" i.Interface.name suffix);
     Block ([
         Line (sprintf "\"\"\"%s\"\"\"" i.Interface.description);
         Line "def __init__(self):";
@@ -259,7 +259,7 @@ let server_of_interface env i =
     | [] -> []
     | x :: xs -> f true x :: (List.map (f false) xs) in
   [
-    Line (sprintf "class %s_server_dispatcher:" i.Interface.name);
+    Line (sprintf "class %s_server_dispatcher(object):" i.Interface.name);
     Block ([
         Line (sprintf "\"\"\"%s\"\"\"" i.Interface.description);
         Line "def __init__(self, impl):";
@@ -349,7 +349,7 @@ let commandline_run env i m =
 let commandline_of_interface env i =
   let open Printf in
   [
-    Line (sprintf "class %s_commandline():" i.Interface.name);
+    Line (sprintf "class %s_commandline(object):" i.Interface.name);
     Block ([
       Line "\"\"\"Parse command-line arguments and call an implementation.\"\"\"";
       Line "def __init__(self, impl):";
@@ -379,7 +379,7 @@ let of_interfaces env i =
                                  (server_of_interface env i) @ (skeleton_of_interface env i) @ (test_impl_of_interface env i) @ (commandline_of_interface env i)
                    ) [] i.Interfaces.interfaces
   ) @ [
-    Line (sprintf "class %s_server_dispatcher:" i.Interfaces.name);
+    Line (sprintf "class %s_server_dispatcher(object):" i.Interfaces.name);
     Block ([
         Line "\"\"\"Demux calls to individual interface server_dispatchers\"\"\"";
         Line (sprintf "def __init__(self%s):" (String.concat "" (List.map (fun x -> ", " ^ x ^ "=None") (List.map (fun i -> i.Interface.name) i.Interfaces.interfaces))));


### PR DESCRIPTION
Part of a series of PR, main PR here: https://github.com/xapi-project/xcp-idl/pull/217

Changes API of SMAPIv3  SR.create and SR.attach to take a device-config map instead of a JSON serialized into a string and called 'uri'.
Probe will return the device-config needed for SR.create/SR.attach.

Backwards compatibility with existing SMAPIv3 plugins is handled in the xapi-storage-script PR: `xapi-storage` always declares the latest APIs and xapi-storage-script takes care of translating the requests/responses in a backward compatible way.
