### PR TITLE
doc,plugin: All plugins need to satisfy query interface

### DIFF
--- a/generator/lib/plugin.ml
+++ b/generator/lib/plugin.ml
@@ -88,5 +88,7 @@ let interfaces = Codegen.Interfaces.create
     ~title:"The Plugin interface"
     ~description:[
       "The xapi toolstack expects all plugins to support a basic query";
+      "interface. This means that if you plan to implement both, a volume";
+      "and a datapath plugin, make sure that both implement the query";
       "interface."]
     ~interfaces:[P.implementation ()]


### PR DESCRIPTION
This is a minor fix and emphasizes that every plugin, datapath as well
as volume plugins need to implement the query interface. For me it was
too easy to overlook that in the documentation.

Closes xapi-project/xapi-storage-script#79.