### PR TITLE
maintenance: fix doc generation

### DIFF
--- a/generator/lib/common.ml
+++ b/generator/lib/common.ml
@@ -17,14 +17,15 @@ let dbg = Param.mk ~name:"dbg" ~description:["Debug context from the caller"] Ty
 let unit = Param.mk Types.unit
 let task_id = Param.mk ~name:"task_id" Types.string
 
-type uri = string [@@deriving rpcty] [@@doc
-  ["A URI representing the means for accessing the volume data. The interpretation ";
-   "of the URI is specific to the implementation. Xapi will choose which ";
-   "implementation to use based on the URI scheme."]]
+(** A URI representing the means for accessing the volume data. The
+    interpretation of the URI is specific to the implementation. Xapi will
+    choose which implementation to use based on the URI scheme. *)
+type uri = string [@@deriving rpcty]
 
+(** List of blocks for copying. *)
 type blocklist = {
-  blocksize : int
-      [@doc ["size of the individual blocks"]];
-  ranges : (int64 * int64) list
-      [@doc ["list of block ranges, where a range is a (start,length) pair, measured in units of [blocksize]"]];
-} [@@deriving rpcty] [@@doc ["List of blocks for copying"]]
+  blocksize : int ; (** Size of the individual blocks. *)
+  ranges : (int64 * int64) list ;
+      (** List of block ranges, where a range is a (start,length) pair,
+          measured in units of [blocksize] *)
+} [@@deriving rpcty]

--- a/generator/lib/plugin.ml
+++ b/generator/lib/plugin.ml
@@ -2,39 +2,33 @@ open Rpc
 open Idl
 open Common
 
+(** Properties of this implementation. *)
 type query_result = {
-  plugin : string [@doc
-      ["plugin name, used in the XenAPI as SR.type"]];
+  plugin : string ; (** Plugin name, used in the XenAPI as SR.type. *)
 
-  name : string  [@key "name"] [@doc
-      ["short name"]];
+  name : string  [@key "name"] ; (** Short name. *)
 
-  description : string [@key "description"] [@doc
-      ["description"]];
+  description : string [@key "description"] ; (** Description. *)
 
-  vendor : string [@doc
-      ["entity (e.g. company, project, group) which produced this ";
-       "implementation"]];
+  vendor : string ;
+  (** Entity (e.g. company, project, group) which produced this
+      implementation. *)
 
-  copyright : string [@doc
-      ["copyright"]];
+  copyright : string ; (** Copyright. *)
 
-  version : string [@doc
-      ["version"]];
+  version : string ; (** Version. *)
 
-  required_api_version : string [@doc
-      ["minimum required API version"]];
+  required_api_version : string ; (** Minimum required API version. *)
 
-  features : string list [@doc
-      ["features supported by this plugin"]];
+  features : string list ; (** Features supported by this plugin. *)
 
-  configuration : (string * string) list [@doc
-      ["key/description pairs describing required device_config parameters"]];
+  configuration : (string * string) list ;
+  (** Key/description pairs describing required device_config parameters. *)
 
-  required_cluster_stack : string list [@doc
-      ["the plugin requires one of these cluster stacks to be active"]];
+  required_cluster_stack : string list ;
+  (** The plugin requires one of these cluster stacks to be active. *)
 
-} [@@deriving rpcty] [@@doc ["Properties of this implementation"]]
+} [@@deriving rpcty]
 
 type srs = string list [@@deriving rpcty]
 

--- a/generator/lib/task.ml
+++ b/generator/lib/task.ml
@@ -6,7 +6,8 @@ open Common
 let doc l = String.concat " " l
 
 type error_t = string [@@deriving rpcty]
-type id = string [@@deriving rpcty] [@@doc ["Unique identifier for a task"]]
+(** Unique identifier for a task. *)
+type id = string [@@deriving rpcty]
 type task_list = id list [@@deriving rpcty]
 
 type async_result_t =
@@ -20,8 +21,8 @@ type completion_t = {
 } [@@deriving rpcty]
 
 type state =
-  | Pending of float [@doc [
-      "the task is in progress, with progress info from 0..1"]]
+  | Pending of float
+    (** The task is in progress, with progress info from 0..1. *)
   | Completed of completion_t
   | Failed of error_t
   [@@deriving rpcty]


### PR DESCRIPTION
Doc building was broken using odoc, changing to ocamldoc tags fixes it.

The documentation was manually checked, same as https://github.com/xapi-project/xcp-idl/pull/300